### PR TITLE
Fix iterator error & implements setIn/updateIn

### DIFF
--- a/immer/array.hpp
+++ b/immer/array.hpp
@@ -20,8 +20,9 @@
 
 #pragma once
 
-#include <immer/memory_policy.hpp>
 #include <immer/detail/arrays/with_capacity.hpp>
+#include <immer/detail/immutable.hpp>
+#include <immer/memory_policy.hpp>
 
 namespace immer {
 
@@ -236,6 +237,14 @@ public:
     template <typename FnT>
     decltype(auto) update(size_type index, FnT&& fn) &&
     { return update_move(move_t{}, index, std::forward<FnT>(fn)); }
+
+    template <typename ... Rest>
+    auto setIn(size_type index, Rest const & ... rest) const
+    { return detail::setIn(*this, index, rest ...); }
+
+    template <typename ... Rest>
+    auto updateIn(size_type index, Rest const & ... rest) const
+    { return detail::updateIn(*this, index, rest ...); }
 
     /*!
      * Returns a array containing only the first `min(elems, size())`

--- a/immer/detail/immutable.hpp
+++ b/immer/detail/immutable.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <functional>
+
+namespace immer {
+namespace detail {
+
+template <typename Container, typename Key, typename Updater>
+static inline auto updateIn(Container const & container, Key const & key, Updater const & updater)
+{
+    return container.update(key, updater);
+}
+
+template <typename Container, typename Key, typename ... Rest>
+static inline auto updateIn(Container const & container, Key const & key, Rest const & ... rest)
+{
+    return container.update(key, [&](auto const & child) {
+        return updateIn(child, rest ...);
+    });
+}
+
+template <typename Container, typename Key, typename Value>
+static inline auto setIn(Container const & container, Key const & key, Value const & value)
+{
+    return container.set(key, value);
+}
+
+template <typename Container, typename Key, typename ... Rest>
+static inline auto setIn(Container const & container, Key const & key, Rest const & ... rest)
+{
+    return container.update(key, [&](auto const & child) {
+        return setIn(child, rest ...);
+    });
+}
+
+}
+}

--- a/immer/detail/rbts/rbtree_iterator.hpp
+++ b/immer/detail/rbts/rbtree_iterator.hpp
@@ -32,7 +32,9 @@ struct rbtree_iterator
     : iterator_facade<rbtree_iterator<T, MP, B, BL>,
                       std::random_access_iterator_tag,
                       T,
-                      const T&>
+                      const T&,
+                      std::ptrdiff_t,
+                      const T*>
 {
     using tree_t = rbtree<T, MP, B, BL>;
 

--- a/immer/detail/rbts/rrbtree_iterator.hpp
+++ b/immer/detail/rbts/rrbtree_iterator.hpp
@@ -32,7 +32,9 @@ struct rrbtree_iterator
     : iterator_facade<rrbtree_iterator<T, MP, B, BL>,
                       std::random_access_iterator_tag,
                       T,
-                      const T&>
+                      const T&,
+                      std::ptrdiff_t,
+                      const T*>
 {
     using tree_t   = rrbtree<T, MP, B, BL>;
     using region_t = std::tuple<const T*, size_t, size_t>;

--- a/immer/flex_vector.hpp
+++ b/immer/flex_vector.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <immer/detail/immutable.hpp>
 #include <immer/detail/rbts/rrbtree.hpp>
 #include <immer/detail/rbts/rrbtree_iterator.hpp>
 #include <immer/memory_policy.hpp>
@@ -280,6 +281,14 @@ public:
     template <typename FnT>
     decltype(auto) update(size_type index, FnT&& fn) &&
     { return update_move(move_t{}, index, std::forward<FnT>(fn)); }
+
+    template <typename ... Rest>
+    auto setIn(size_type index, Rest const & ... rest) const
+    { return detail::setIn(*this, index, rest ...); }
+
+    template <typename ... Rest>
+    auto updateIn(size_type index, Rest const & ... rest) const
+    { return detail::updateIn(*this, index, rest ...); }
 
     /*!
      * Returns a vector containing only the first `min(elems, size())`

--- a/immer/vector.hpp
+++ b/immer/vector.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <immer/detail/immutable.hpp>
 #include <immer/detail/rbts/rbtree.hpp>
 #include <immer/detail/rbts/rbtree_iterator.hpp>
 #include <immer/memory_policy.hpp>
@@ -262,6 +263,14 @@ public:
     template <typename FnT>
     decltype(auto) update(size_type index, FnT&& fn) &&
     { return update_move(move_t{}, index, std::forward<FnT>(fn)); }
+
+    template <typename ... Rest>
+    auto setIn(size_type index, Rest const & ... rest) const
+    { return detail::setIn(*this, index, rest ...); }
+
+    template <typename ... Rest>
+    auto updateIn(size_type index, Rest const & ... rest) const
+    { return detail::updateIn(*this, index, rest ...); }
 
     /*!
      * Returns a vector containing only the first `min(elems, size())`


### PR DESCRIPTION
I haven't wrote documentation, and there might be some more work to do to implement move semantic, but I figured you'd be interested to take a look at this. I'm using them, and they seem to work fairly well!

They operate the exact same way than `.set()` and `.update()`, except that they accept any number of key (the compilation will fail if there's too many keys).