### PR TITLE
Persistent hash maps and sets

### DIFF
--- a/benchmark/set/access.cpp
+++ b/benchmark/set/access.cpp
@@ -1,0 +1,203 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "benchmark/config.hpp"
+
+#include <immer/set.hpp>
+
+#include <hash_trie.hpp> // Phil Nash
+
+#include <boost/container/flat_set.hpp>
+
+#include <set>
+#include <unordered_set>
+
+template <typename T=unsigned>
+auto make_generator(std::size_t runs)
+{
+    assert(runs > 0);
+    auto engine = std::default_random_engine{42};
+    auto dist = std::uniform_int_distribution<T>{};
+    auto r = std::vector<T>(runs);
+    std::generate_n(r.begin(), runs, std::bind(dist, engine));
+    return r;
+}
+
+template <typename T=unsigned>
+auto make_generator_ranged(std::size_t runs)
+{
+    assert(runs > 0);
+    auto engine = std::default_random_engine{13};
+    auto dist = std::uniform_int_distribution<T>{0, (T)runs-1};
+    auto r = std::vector<T>(runs);
+    std::generate_n(r.begin(), runs, std::bind(dist, engine));
+    return r;
+}
+
+template <typename Set>
+auto benchmark_access_std()
+{
+    return [] (nonius::chronometer meter)
+    {
+        auto n  = meter.param<N>();
+        auto g1 = make_generator(n);
+        auto g2 = make_generator_ranged(n);
+
+        auto v = Set{};
+        for (auto i = 0u; i < n; ++i)
+            v.insert(g1[i]);
+
+        measure(meter, [&] {
+            auto c = 0u;
+            for (auto i = 0u; i < n; ++i)
+                c += v.count(g1[g2[i]]);
+            volatile auto r = c;
+            return r;
+        });
+    };
+};
+
+template <typename Set>
+auto benchmark_access_hamt()
+{
+    return [] (nonius::chronometer meter)
+    {
+        auto n = meter.param<N>();
+        auto g1 = make_generator(n);
+        auto g2 = make_generator_ranged(n);
+
+        auto v = Set{};
+        for (auto i = 0u; i < n; ++i)
+            v.insert(g1[i]);
+
+        measure(meter, [&] {
+            auto c = 0u;
+            for (auto i = 0u; i < n; ++i)
+                c += !!v.find(g1[g2[i]]).leaf();
+            volatile auto r = c;
+            return r;
+        });
+    };
+};
+
+
+template <typename Set>
+auto benchmark_access()
+{
+    return [] (nonius::chronometer meter)
+    {
+        auto n = meter.param<N>();
+        auto g1 = make_generator(n);
+        auto g2 = make_generator_ranged(n);
+
+        auto v = Set{};
+        for (auto i = 0u; i < n; ++i)
+            v = v.insert(g1[i]);
+
+        measure(meter, [&] {
+            auto c = 0u;
+            for (auto i = 0u; i < n; ++i)
+                c += v.count(g1[g2[i]]);
+            volatile auto r = c;
+            return r;
+        });
+    };
+};
+
+template <typename Set>
+auto benchmark_bad_access_std()
+{
+    return [] (nonius::chronometer meter)
+    {
+        auto n = meter.param<N>();
+        auto g1 = make_generator(n*2);
+
+        auto v = Set{};
+        for (auto i = 0u; i < n; ++i)
+            v.insert(g1[i]);
+
+        measure(meter, [&] {
+            auto c = 0u;
+            for (auto i = 0u; i < n; ++i)
+                c += v.count(g1[n+i]);
+            volatile auto r = c;
+            return r;
+        });
+    };
+};
+
+template <typename Set>
+auto benchmark_bad_access_hamt()
+{
+    return [] (nonius::chronometer meter)
+    {
+        auto n = meter.param<N>();
+        auto g1 = make_generator(n*2);
+
+        auto v = Set{};
+        for (auto i = 0u; i < n; ++i)
+            v.insert(g1[i]);
+
+        measure(meter, [&] {
+            auto c = 0u;
+            for (auto i = 0u; i < n; ++i)
+                c += !!v.find(g1[n+i]).leaf();
+            volatile auto r = c;
+            return r;
+        });
+    };
+};
+
+
+template <typename Set>
+auto benchmark_bad_access()
+{
+    return [] (nonius::chronometer meter)
+    {
+        auto n = meter.param<N>();
+        auto g1 = make_generator(n*2);
+
+        auto v = Set{};
+        for (auto i = 0u; i < n; ++i)
+            v = v.insert(g1[i]);
+
+        measure(meter, [&] {
+            auto c = 0u;
+            for (auto i = 0u; i < n; ++i)
+                c += v.count(g1[n+i]);
+            volatile auto r = c;
+            return r;
+        });
+    };
+};
+
+NONIUS_BENCHMARK("std::set", benchmark_access_std<std::set<unsigned>>())
+NONIUS_BENCHMARK("std::unordered_set", benchmark_access_std<std::unordered_set<unsigned>>())
+NONIUS_BENCHMARK("boost::flat_set", benchmark_access_std<boost::container::flat_set<unsigned>>())
+NONIUS_BENCHMARK("hamt::hash_trie", benchmark_access_hamt<hamt::hash_trie<unsigned>>())
+NONIUS_BENCHMARK("immer::set/5B", benchmark_access<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,def_memory,5>>())
+NONIUS_BENCHMARK("immer::set/4B", benchmark_access<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,def_memory,4>>())
+
+NONIUS_BENCHMARK("bad/std::set", benchmark_bad_access_std<std::set<unsigned>>())
+NONIUS_BENCHMARK("bad/std::unordered_set", benchmark_bad_access_std<std::unordered_set<unsigned>>())
+NONIUS_BENCHMARK("bad/boost::flat_set", benchmark_bad_access_std<boost::container::flat_set<unsigned>>())
+NONIUS_BENCHMARK("bad/hamt::hash_trie", benchmark_bad_access_hamt<hamt::hash_trie<unsigned>>())
+NONIUS_BENCHMARK("bad/immer::set/5B", benchmark_bad_access<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,def_memory,5>>())
+NONIUS_BENCHMARK("bad/immer::set/4B", benchmark_bad_access<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,def_memory,4>>())

--- a/benchmark/set/access.ipp
+++ b/benchmark/set/access.ipp
@@ -1,0 +1,42 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "access.hpp"
+
+#ifndef GENERATOR_T
+#error "you must define a GENERATOR_T"
+#endif
+
+using generator__ = GENERATOR_T;
+using t__ = typename decltype(generator__{}(0))::value_type;
+
+NONIUS_BENCHMARK("std::set", benchmark_access_std<generator__, std::set<t__>>())
+NONIUS_BENCHMARK("std::unordered_set", benchmark_access_std<generator__, std::unordered_set<t__>>())
+NONIUS_BENCHMARK("boost::flat_set", benchmark_access_std<generator__, boost::container::flat_set<t__>>())
+NONIUS_BENCHMARK("hamt::hash_trie", benchmark_access_hamt<generator__, hamt::hash_trie<t__>>())
+NONIUS_BENCHMARK("immer::set/5B", benchmark_access<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,5>>())
+NONIUS_BENCHMARK("immer::set/4B", benchmark_access<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,4>>())
+
+NONIUS_BENCHMARK("bad/std::set", benchmark_bad_access_std<generator__, std::set<t__>>())
+NONIUS_BENCHMARK("bad/std::unordered_set", benchmark_bad_access_std<generator__, std::unordered_set<t__>>())
+NONIUS_BENCHMARK("bad/boost::flat_set", benchmark_bad_access_std<generator__, boost::container::flat_set<t__>>())
+NONIUS_BENCHMARK("bad/hamt::hash_trie", benchmark_bad_access_hamt<generator__, hamt::hash_trie<t__>>())
+NONIUS_BENCHMARK("bad/immer::set/5B", benchmark_bad_access<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,5>>())
+NONIUS_BENCHMARK("bad/immer::set/4B", benchmark_bad_access<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,4>>())

--- a/benchmark/set/insert.cpp
+++ b/benchmark/set/insert.cpp
@@ -1,0 +1,85 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "benchmark/config.hpp"
+
+#include <immer/set.hpp>
+
+#include <hash_trie.hpp> // Phil Nash
+
+#include <boost/container/flat_set.hpp>
+
+#include <set>
+#include <unordered_set>
+
+template <typename T=unsigned>
+auto make_generator(std::size_t runs)
+{
+    assert(runs > 0);
+    auto engine = std::default_random_engine{42};
+    auto dist = std::uniform_int_distribution<T>{};
+    auto r = std::vector<T>(runs);
+    std::generate_n(r.begin(), runs, std::bind(dist, engine));
+    return r;
+}
+
+template <typename Set>
+auto benchmark_insert_mut_std()
+{
+    return [] (nonius::chronometer meter)
+    {
+        auto n = meter.param<N>();
+        auto g = make_generator(n);
+
+        measure(meter, [&] {
+            auto v = Set{};
+            for (auto i = 0u; i < n; ++i)
+                v.insert(g[i]);
+            return v;
+        });
+    };
+};
+
+template <typename Set>
+auto benchmark_insert()
+{
+    return [] (nonius::chronometer meter)
+    {
+        auto n = meter.param<N>();
+        auto g = make_generator(n);
+
+        measure(meter, [&] {
+            auto v = Set{};
+            for (auto i = 0u; i < n; ++i)
+                v = v.insert(g[i]);
+            return v;
+        });
+    };
+};
+
+NONIUS_BENCHMARK("std::set", benchmark_insert_mut_std<std::set<unsigned>>())
+NONIUS_BENCHMARK("std::unordered_set", benchmark_insert_mut_std<std::unordered_set<unsigned>>())
+NONIUS_BENCHMARK("boost::flat_set", benchmark_insert_mut_std<boost::container::flat_set<unsigned>>())
+NONIUS_BENCHMARK("hamt::hash_trie", benchmark_insert_mut_std<hamt::hash_trie<unsigned>>())
+
+NONIUS_BENCHMARK("immer::set/5B", benchmark_insert<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,def_memory,5>>())
+NONIUS_BENCHMARK("immer::set/4B", benchmark_insert<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,def_memory,4>>())
+NONIUS_BENCHMARK("immer::set/GC", benchmark_insert<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,gc_memory,5>>())
+NONIUS_BENCHMARK("immer::set/UN", benchmark_insert<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,unsafe_memory,5>>())

--- a/benchmark/set/insert.hpp
+++ b/benchmark/set/insert.hpp
@@ -18,35 +18,25 @@
 // along with immer.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+#pragma once
+
 #include "benchmark/config.hpp"
 
 #include <immer/set.hpp>
-
 #include <hash_trie.hpp> // Phil Nash
-
 #include <boost/container/flat_set.hpp>
-
 #include <set>
 #include <unordered_set>
 
-template <typename T=unsigned>
-auto make_generator(std::size_t runs)
-{
-    assert(runs > 0);
-    auto engine = std::default_random_engine{42};
-    auto dist = std::uniform_int_distribution<T>{};
-    auto r = std::vector<T>(runs);
-    std::generate_n(r.begin(), runs, std::bind(dist, engine));
-    return r;
-}
+namespace {
 
-template <typename Set>
+template <typename Generator, typename Set>
 auto benchmark_insert_mut_std()
 {
     return [] (nonius::chronometer meter)
     {
         auto n = meter.param<N>();
-        auto g = make_generator(n);
+        auto g = Generator{}(n);
 
         measure(meter, [&] {
             auto v = Set{};
@@ -57,13 +47,13 @@ auto benchmark_insert_mut_std()
     };
 };
 
-template <typename Set>
+template <typename Generator, typename Set>
 auto benchmark_insert()
 {
     return [] (nonius::chronometer meter)
     {
         auto n = meter.param<N>();
-        auto g = make_generator(n);
+        auto g = Generator{}(n);
 
         measure(meter, [&] {
             auto v = Set{};
@@ -74,12 +64,4 @@ auto benchmark_insert()
     };
 };
 
-NONIUS_BENCHMARK("std::set", benchmark_insert_mut_std<std::set<unsigned>>())
-NONIUS_BENCHMARK("std::unordered_set", benchmark_insert_mut_std<std::unordered_set<unsigned>>())
-NONIUS_BENCHMARK("boost::flat_set", benchmark_insert_mut_std<boost::container::flat_set<unsigned>>())
-NONIUS_BENCHMARK("hamt::hash_trie", benchmark_insert_mut_std<hamt::hash_trie<unsigned>>())
-
-NONIUS_BENCHMARK("immer::set/5B", benchmark_insert<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,def_memory,5>>())
-NONIUS_BENCHMARK("immer::set/4B", benchmark_insert<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,def_memory,4>>())
-NONIUS_BENCHMARK("immer::set/GC", benchmark_insert<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,gc_memory,5>>())
-NONIUS_BENCHMARK("immer::set/UN", benchmark_insert<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,unsafe_memory,5>>())
+} // namespace

--- a/benchmark/set/insert.ipp
+++ b/benchmark/set/insert.ipp
@@ -1,0 +1,40 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "insert.hpp"
+
+#ifndef GENERATOR_T
+#error "you must define a GENERATOR_T"
+#endif
+
+using generator__ = GENERATOR_T;
+using t__ = typename decltype(generator__{}(0))::value_type;
+
+NONIUS_BENCHMARK("std::set", benchmark_insert_mut_std<generator__, std::set<t__>>())
+NONIUS_BENCHMARK("std::unordered_set", benchmark_insert_mut_std<generator__, std::unordered_set<t__>>())
+NONIUS_BENCHMARK("boost::flat_set", benchmark_insert_mut_std<generator__, boost::container::flat_set<t__>>())
+NONIUS_BENCHMARK("hamt::hash_trie", benchmark_insert_mut_std<generator__, hamt::hash_trie<t__>>())
+
+NONIUS_BENCHMARK("immer::set/5B", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,5>>())
+NONIUS_BENCHMARK("immer::set/4B", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,4>>())
+#ifndef DISABLE_GC_BENCHMARKS
+NONIUS_BENCHMARK("immer::set/GC", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,gc_memory,5>>())
+#endif
+NONIUS_BENCHMARK("immer::set/UN", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,unsafe_memory,5>>())

--- a/benchmark/set/iter.cpp
+++ b/benchmark/set/iter.cpp
@@ -1,0 +1,110 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "benchmark/config.hpp"
+
+#include <immer/set.hpp>
+#include <immer/algorithm.hpp>
+
+#include <hash_trie.hpp> // Phil Nash
+
+#include <boost/container/flat_set.hpp>
+
+#include <set>
+#include <unordered_set>
+#include <numeric>
+
+template <typename T=unsigned>
+auto make_generator(std::size_t runs)
+{
+    assert(runs > 0);
+    auto engine = std::default_random_engine{42};
+    auto dist = std::uniform_int_distribution<T>{};
+    auto r = std::vector<T>(runs);
+    std::generate_n(r.begin(), runs, std::bind(dist, engine));
+    return r;
+}
+
+template <typename Set>
+auto benchmark_access_std_iter()
+{
+    return [] (nonius::chronometer meter)
+    {
+        auto n  = meter.param<N>();
+        auto g1 = make_generator(n);
+
+        auto v = Set{};
+        for (auto i = 0u; i < n; ++i)
+            v.insert(g1[i]);
+
+        measure(meter, [&] {
+            volatile auto c = std::accumulate(v.begin(), v.end(), 0u);
+            return c;
+        });
+    };
+};
+
+template <typename Set>
+auto benchmark_access_reduce()
+{
+    return [] (nonius::chronometer meter)
+    {
+        auto n = meter.param<N>();
+        auto g1 = make_generator(n);
+
+        auto v = Set{};
+        for (auto i = 0u; i < n; ++i)
+            v = v.insert(g1[i]);
+
+        measure(meter, [&] {
+            volatile auto c = immer::accumulate(v, 0u);
+            return c;
+        });
+    };
+};
+
+template <typename Set>
+auto benchmark_access_iter()
+{
+    return [] (nonius::chronometer meter)
+    {
+        auto n = meter.param<N>();
+        auto g1 = make_generator(n);
+
+        auto v = Set{};
+        for (auto i = 0u; i < n; ++i)
+            v = v.insert(g1[i]);
+
+        measure(meter, [&] {
+            volatile auto c = std::accumulate(v.begin(), v.end(), 0u);
+            return c;
+        });
+    };
+};
+
+NONIUS_BENCHMARK("iter/std::set", benchmark_access_std_iter<std::set<unsigned>>())
+NONIUS_BENCHMARK("iter/std::unordered_set", benchmark_access_std_iter<std::unordered_set<unsigned>>())
+NONIUS_BENCHMARK("iter/boost::flat_set", benchmark_access_std_iter<boost::container::flat_set<unsigned>>())
+NONIUS_BENCHMARK("iter/hamt::hash_trie", benchmark_access_std_iter<hamt::hash_trie<unsigned>>())
+NONIUS_BENCHMARK("iter/immer::set/5B", benchmark_access_iter<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,def_memory,5>>())
+NONIUS_BENCHMARK("iter/immer::set/4B", benchmark_access_iter<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,def_memory,4>>())
+
+NONIUS_BENCHMARK("reduce/immer::set/5B", benchmark_access_reduce<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,def_memory,5>>())
+NONIUS_BENCHMARK("reduce/immer::set/4B", benchmark_access_reduce<immer::set<unsigned, std::hash<unsigned>,std::equal_to<unsigned>,def_memory,4>>())

--- a/benchmark/set/iter.ipp
+++ b/benchmark/set/iter.ipp
@@ -1,0 +1,37 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "iter.hpp"
+
+#ifndef GENERATOR_T
+#error "you must define a GENERATOR_T"
+#endif
+
+using generator__ = GENERATOR_T;
+using t__ = typename decltype(generator__{}(0))::value_type;
+
+NONIUS_BENCHMARK("iter/std::set", benchmark_access_std_iter<generator__, std::set<t__>>())
+NONIUS_BENCHMARK("iter/std::unordered_set", benchmark_access_std_iter<generator__, std::unordered_set<t__>>())
+NONIUS_BENCHMARK("iter/boost::flat_set", benchmark_access_std_iter<generator__, boost::container::flat_set<t__>>())
+NONIUS_BENCHMARK("iter/hamt::hash_trie", benchmark_access_std_iter<generator__, hamt::hash_trie<t__>>())
+NONIUS_BENCHMARK("iter/immer::set/5B", benchmark_access_iter<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,5>>())
+NONIUS_BENCHMARK("iter/immer::set/4B", benchmark_access_iter<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,4>>())
+NONIUS_BENCHMARK("reduce/immer::set/5B", benchmark_access_reduce<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,5>>())
+NONIUS_BENCHMARK("reduce/immer::set/4B", benchmark_access_reduce<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,4>>())

--- a/benchmark/set/string-box/access.cpp
+++ b/benchmark/set/string-box/access.cpp
@@ -1,0 +1,22 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "generator.ipp"
+#include "../access.ipp"

--- a/benchmark/set/string-box/generator.ipp
+++ b/benchmark/set/string-box/generator.ipp
@@ -1,0 +1,58 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <immer/box.hpp>
+
+#include <random>
+#include <vector>
+#include <cassert>
+#include <functional>
+#include <algorithm>
+
+#define GENERATOR_T generate_unsigned
+
+namespace {
+
+struct GENERATOR_T
+{
+    static constexpr auto char_set   = "_-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    static constexpr auto max_length = 64;
+    static constexpr auto min_length = 8;
+
+    auto operator() (std::size_t runs) const
+    {
+        assert(runs > 0);
+        auto engine = std::default_random_engine{42};
+        auto dist = std::uniform_int_distribution<unsigned>{};
+        auto gen = std::bind(dist, engine);
+        auto r = std::vector<immer::box<std::string>>(runs);
+        std::generate_n(r.begin(), runs, [&] {
+            auto len = gen() % (max_length - min_length) + min_length;
+            auto str = std::string(len, ' ');
+            std::generate_n(str.begin(), len, [&] {
+                return char_set[gen() % sizeof(char_set)];
+            });
+            return str;
+        });
+        return r;
+    }
+};
+
+} // namespace

--- a/benchmark/set/string-box/insert.cpp
+++ b/benchmark/set/string-box/insert.cpp
@@ -1,0 +1,23 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#define DISABLE_GC_BENCHMARKS
+#include "generator.ipp"
+#include "../insert.ipp"

--- a/benchmark/set/string-box/iter.cpp
+++ b/benchmark/set/string-box/iter.cpp
@@ -1,0 +1,22 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "generator.ipp"
+#include "../iter.ipp"

--- a/benchmark/set/string-long/access.cpp
+++ b/benchmark/set/string-long/access.cpp
@@ -1,0 +1,22 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "generator.ipp"
+#include "../access.ipp"

--- a/benchmark/set/string-long/generator.ipp
+++ b/benchmark/set/string-long/generator.ipp
@@ -1,0 +1,56 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <random>
+#include <vector>
+#include <cassert>
+#include <functional>
+#include <algorithm>
+
+#define GENERATOR_T generate_unsigned
+
+namespace {
+
+struct GENERATOR_T
+{
+    static constexpr auto char_set   = "_-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    static constexpr auto max_length = 256;
+    static constexpr auto min_length = 32;
+
+    auto operator() (std::size_t runs) const
+    {
+        assert(runs > 0);
+        auto engine = std::default_random_engine{42};
+        auto dist = std::uniform_int_distribution<unsigned>{};
+        auto gen = std::bind(dist, engine);
+        auto r = std::vector<std::string>(runs);
+        std::generate_n(r.begin(), runs, [&] {
+            auto len = gen() % (max_length - min_length) + min_length;
+            auto str = std::string(len, ' ');
+            std::generate_n(str.begin(), len, [&] {
+                return char_set[gen() % sizeof(char_set)];
+            });
+            return str;
+        });
+        return r;
+    }
+};
+
+} // namespace

--- a/benchmark/set/string-long/insert.cpp
+++ b/benchmark/set/string-long/insert.cpp
@@ -1,0 +1,23 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#define DISABLE_GC_BENCHMARKS
+#include "generator.ipp"
+#include "../insert.ipp"

--- a/benchmark/set/string-long/iter.cpp
+++ b/benchmark/set/string-long/iter.cpp
@@ -1,0 +1,22 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "generator.ipp"
+#include "../iter.ipp"

--- a/benchmark/set/string-short/access.cpp
+++ b/benchmark/set/string-short/access.cpp
@@ -1,0 +1,22 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "generator.ipp"
+#include "../access.ipp"

--- a/benchmark/set/string-short/generator.ipp
+++ b/benchmark/set/string-short/generator.ipp
@@ -1,0 +1,56 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <random>
+#include <vector>
+#include <cassert>
+#include <functional>
+#include <algorithm>
+
+#define GENERATOR_T generate_unsigned
+
+namespace {
+
+struct GENERATOR_T
+{
+    static constexpr auto char_set   = "_-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    static constexpr auto max_length = 15;
+    static constexpr auto min_length = 4;
+
+    auto operator() (std::size_t runs) const
+    {
+        assert(runs > 0);
+        auto engine = std::default_random_engine{42};
+        auto dist = std::uniform_int_distribution<unsigned>{};
+        auto gen = std::bind(dist, engine);
+        auto r = std::vector<std::string>(runs);
+        std::generate_n(r.begin(), runs, [&] {
+            auto len = gen() % (max_length - min_length) + min_length;
+            auto str = std::string(len, ' ');
+            std::generate_n(str.begin(), len, [&] {
+                return char_set[gen() % sizeof(char_set)];
+            });
+            return str;
+        });
+        return r;
+    }
+};
+
+} // namespace

--- a/benchmark/set/string-short/insert.cpp
+++ b/benchmark/set/string-short/insert.cpp
@@ -1,0 +1,22 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "generator.ipp"
+#include "../insert.ipp"

--- a/benchmark/set/string-short/iter.cpp
+++ b/benchmark/set/string-short/iter.cpp
@@ -1,0 +1,22 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "generator.ipp"
+#include "../iter.ipp"

--- a/benchmark/set/unsigned/access.cpp
+++ b/benchmark/set/unsigned/access.cpp
@@ -1,0 +1,22 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "generator.ipp"
+#include "../access.ipp"

--- a/benchmark/set/unsigned/generator.ipp
+++ b/benchmark/set/unsigned/generator.ipp
@@ -1,0 +1,44 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <random>
+#include <vector>
+#include <cassert>
+#include <functional>
+#include <algorithm>
+
+#define GENERATOR_T generate_unsigned
+
+namespace {
+
+struct GENERATOR_T
+{
+    auto operator() (std::size_t runs) const
+    {
+        assert(runs > 0);
+        auto engine = std::default_random_engine{42};
+        auto dist = std::uniform_int_distribution<unsigned>{};
+        auto r = std::vector<unsigned>(runs);
+        std::generate_n(r.begin(), runs, std::bind(dist, engine));
+        return r;
+    }
+};
+
+} // namespace

--- a/benchmark/set/unsigned/insert.cpp
+++ b/benchmark/set/unsigned/insert.cpp
@@ -1,0 +1,22 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "generator.ipp"
+#include "../insert.ipp"

--- a/benchmark/set/unsigned/iter.cpp
+++ b/benchmark/set/unsigned/iter.cpp
@@ -1,0 +1,22 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "generator.ipp"
+#include "../iter.ipp"

--- a/doc/containers.rst
+++ b/doc/containers.rst
@@ -192,3 +192,17 @@ flex_vector
 .. doxygenclass:: immer::flex_vector
     :members:
     :undoc-members:
+
+set
+---
+
+.. doxygenclass:: immer::set
+    :members:
+    :undoc-members:
+
+map
+---
+
+.. doxygenclass:: immer::map
+    :members:
+    :undoc-members:

--- a/doc/transients.rst
+++ b/doc/transients.rst
@@ -93,3 +93,17 @@ flex_vector_transient
 .. doxygenclass:: immer::flex_vector_transient
     :members:
     :undoc-members:
+
+set_transient
+-------------
+
+.. doxygenclass:: immer::set_transient
+    :members:
+    :undoc-members:
+
+map_transient
+-------------
+
+.. doxygenclass:: immer::map_transient
+    :members:
+    :undoc-members:

--- a/example/map/intro.cpp
+++ b/example/map/intro.cpp
@@ -18,17 +18,18 @@
 // along with immer.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <string>
 // include:intro/start
-#include <immer/vector.hpp>
+#include <immer/map.hpp>
 int main()
 {
-    const auto v0 = immer::vector<int>{};
-    const auto v1 = v0.push_back(13);
-    assert((v0 == immer::vector<int>{}));
-    assert((v1 == immer::vector<int>{13}));
+    const auto v0 = immer::map<std::string, int>{};
+    const auto v1 = v0.set("hello", 42);
+    assert(v0["hello"] == 0);
+    assert(v1["hello"] == 42);
 
-    const auto v2 = v1.set(0, 42);
-    assert(v1[0] == 13);
-    assert(v2[0] == 42);
+    const auto v2 = v1.erase("hello");
+    assert(*v1.find("hello") == 42);
+    assert(!v2.find("hello"));
 }
 // include:intro/end

--- a/example/set/intro.cpp
+++ b/example/set/intro.cpp
@@ -1,0 +1,35 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+// include:intro/start
+#include <immer/set.hpp>
+int main()
+{
+    const auto v0 = immer::set<int>{};
+    const auto v1 = v0.insert(42);
+    assert(v0.size() == 0 &&
+           v1.size() == 1 &&
+           v1.count(42) == 1);
+
+    const auto v2 = v1.erase(42);
+    assert(v1.count(42) &&
+           !v2.count(42));
+}
+// include:intro/end

--- a/example/set/intro.cpp
+++ b/example/set/intro.cpp
@@ -24,12 +24,11 @@ int main()
 {
     const auto v0 = immer::set<int>{};
     const auto v1 = v0.insert(42);
-    assert(v0.size() == 0 &&
-           v1.size() == 1 &&
-           v1.count(42) == 1);
+    assert(v0.count(42) == 0);
+    assert(v1.count(42) == 1);
 
     const auto v2 = v1.erase(42);
-    assert(v1.count(42) &&
-           !v2.count(42));
+    assert(v1.count(42) == 1);
+    assert(v2.count(42) == 0);
 }
 // include:intro/end

--- a/immer/array.hpp
+++ b/immer/array.hpp
@@ -164,10 +164,21 @@ public:
 
     /*!
      * Returns a `const` reference to the element at position `index`.
-     * It does not allocate memory and its complexity is @f$ O(1) @f$.
+     * It is undefined when @f$ 0 index \geq size() @f$.  It does not
+     * allocate memory and its complexity is *effectively* @f$ O(1)
+     * @f$.
      */
     reference operator[] (size_type index) const
     { return impl_.get(index); }
+
+    /*!
+     * Returns a `const` reference to the element at position
+     * `index`. It throws an `std::out_of_range` exception when @f$
+     * index \geq size() @f$.  It does not allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     */
+    reference at(size_type index) const
+    { return impl_.get_check(index); }
 
     /*!
      * Returns whether the vectors are equal.

--- a/immer/array_transient.hpp
+++ b/immer/array_transient.hpp
@@ -123,10 +123,21 @@ public:
 
     /*!
      * Returns a `const` reference to the element at position `index`.
-     * It does not allocate memory and its complexity is @f$ O(1) @f$.
+     * It is undefined when @f$ 0 index \geq size() @f$.  It does not
+     * allocate memory and its complexity is *effectively* @f$ O(1)
+     * @f$.
      */
     reference operator[] (size_type index) const
     { return impl_.get(index); }
+
+    /*!
+     * Returns a `const` reference to the element at position
+     * `index`. It throws an `std::out_of_range` exception when @f$
+     * index \geq size() @f$.  It does not allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     */
+    reference at(size_type index) const
+    { return impl_.get_check(index); }
 
     /*!
      * Inserts `value` at the end.  It may allocate memory and its

--- a/immer/box.hpp
+++ b/immer/box.hpp
@@ -120,6 +120,8 @@ public:
     // to a box (which causes an allocation) just to compare it.
     bool operator!=(detail::exact_t<const box&> other) const
     { return !(*this == other.value); }
+    bool operator<(detail::exact_t<const box&> other) const
+    { return get() < other.value.get(); }
 
     /*!
      * Returns a new box built by applying the `fn` to the underlying
@@ -153,3 +155,16 @@ public:
 };
 
 } // namespace immer
+
+namespace std {
+
+template <typename T, typename MP>
+struct hash<immer::box<T, MP>>
+{
+    std::size_t operator() (const immer::box<T, MP>& x) const
+    {
+        return std::hash<T>{}(*x);
+    }
+};
+
+} // namespace std

--- a/immer/config.hpp
+++ b/immer/config.hpp
@@ -20,13 +20,15 @@
 
 #pragma once
 
-#ifdef NDEBUG
+#ifndef IMMER_DEBUG_TRACES
 #define IMMER_DEBUG_TRACES 0
+#endif
+
+#ifndef IMMER_DEBUG_PRINT
 #define IMMER_DEBUG_PRINT 0
-#define IMMER_DEBUG_DEEP_CHECK 0
-#else
-#define IMMER_DEBUG_TRACES 0
-#define IMMER_DEBUG_PRINT 0
+#endif
+
+#ifndef IMMER_DEBUG_DEEP_CHECK
 #define IMMER_DEBUG_DEEP_CHECK 0
 #endif
 

--- a/immer/detail/arrays/no_capacity.hpp
+++ b/immer/detail/arrays/no_capacity.hpp
@@ -134,6 +134,13 @@ struct no_capacity
         return data()[index];
     }
 
+    const T& get_check(std::size_t index) const
+    {
+        if (index >= size)
+            throw std::out_of_range{"out of range"};
+        return data()[index];
+    }
+
     bool equals(const no_capacity& other) const
     {
         return ptr == other.ptr ||

--- a/immer/detail/arrays/with_capacity.hpp
+++ b/immer/detail/arrays/with_capacity.hpp
@@ -155,6 +155,13 @@ struct with_capacity
         return data()[index];
     }
 
+    const T& get_check(std::size_t index) const
+    {
+        if (index >= size)
+            throw std::out_of_range{"out of range"};
+        return data()[index];
+    }
+
     bool equals(const with_capacity& other) const
     {
         return ptr == other.ptr ||

--- a/immer/detail/hamts/bits.hpp
+++ b/immer/detail/hamts/bits.hpp
@@ -40,10 +40,10 @@ template <bits_t B, typename T=size_t>
 constexpr T mask = branches<B, T> - 1;
 
 template <bits_t B, typename T=count_t>
-constexpr T max_depth = sizeof(hash_t) / B;
+constexpr T max_depth = (sizeof(hash_t) * 8 + B - 1) / B;
 
 template <bits_t B, typename T=count_t>
-constexpr T max_shift = (sizeof(hash_t) / B) * B;
+constexpr T max_shift = max_depth<B, count_t> * B;
 
 #define IMMER_HAS_BUILTIN_POPCOUNT 1
 

--- a/immer/detail/hamts/bits.hpp
+++ b/immer/detail/hamts/bits.hpp
@@ -1,0 +1,42 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+
+#include <cstdint>
+
+namespace immer {
+namespace detail {
+namespace hamts {
+
+using bits_t   = std::uint32_t;
+using bitmap_t = std::uint32_t;
+using count_t  = std::uint32_t;
+using size_t   = std::size_t;
+
+template <bits_t B, typename T=count_t>
+constexpr T branches = T{1} << B;
+
+template <bits_t B, typename T=size_t>
+constexpr T mask = branches<B, T> - 1;
+
+} // namespace hamts
+} // namespace detail
+} // namespace immer

--- a/immer/detail/hamts/bits.hpp
+++ b/immer/detail/hamts/bits.hpp
@@ -29,13 +29,35 @@ namespace hamts {
 using bits_t   = std::uint32_t;
 using bitmap_t = std::uint32_t;
 using count_t  = std::uint32_t;
+using shift_t  = std::uint32_t;
 using size_t   = std::size_t;
+using hash_t   = std::size_t;
 
 template <bits_t B, typename T=count_t>
 constexpr T branches = T{1} << B;
 
 template <bits_t B, typename T=size_t>
 constexpr T mask = branches<B, T> - 1;
+
+template <bits_t B, typename T=count_t>
+constexpr T max_depth = sizeof(hash_t) / B;
+
+#define IMMER_HAS_BUILTIN_POPCOUNT 1
+
+inline auto popcount(bitmap_t x)
+{
+#if IMMER_HAS_BUILTIN_POPCOUNT
+    return __builtin_popcount(x);
+#else
+    // More alternatives:
+    // https://en.wikipedia.org/wiki/Hamming_weight
+    // http://wm.ite.pl/articles/sse-popcount.html
+    // http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
+    x = x - ((x >> 1) & 0x55555555);
+    x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
+    return ((x + (x >> 4) & 0xF0F0F0F) * 0x1010101) >> 24;
+#endif
+}
 
 } // namespace hamts
 } // namespace detail

--- a/immer/detail/hamts/bits.hpp
+++ b/immer/detail/hamts/bits.hpp
@@ -42,9 +42,12 @@ constexpr T mask = branches<B, T> - 1;
 template <bits_t B, typename T=count_t>
 constexpr T max_depth = sizeof(hash_t) / B;
 
+template <bits_t B, typename T=count_t>
+constexpr T max_shift = (sizeof(hash_t) / B) * B;
+
 #define IMMER_HAS_BUILTIN_POPCOUNT 1
 
-inline auto popcount(bitmap_t x)
+inline count_t popcount(bitmap_t x)
 {
 #if IMMER_HAS_BUILTIN_POPCOUNT
     return __builtin_popcount(x);

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -116,16 +116,12 @@ struct champ
         auto node = root;
         auto hash = Hash{}(k);
         for (auto i = count_t{}; i < max_depth<B>; ++i) {
-            IMMER_TRACE("iterate");
-            IMMER_TRACE_E(i);
             auto bit = 1 << (hash & mask<B>);
             if (node->nodemap() & bit) {
-                IMMER_TRACE("node");
                 auto offset = popcount(node->nodemap() & (bit - 1));
                 node = node->children() [offset];
                 hash = hash >> B;
             } else if (node->datamap() & bit) {
-                IMMER_TRACE("data");
                 auto offset = popcount(node->datamap() & (bit - 1));
                 auto val    = node->values() + offset;
                 if (Equal{}(*val, k))
@@ -133,7 +129,6 @@ struct champ
                 else
                     return nullptr;
             } else {
-                IMMER_TRACE("return");
                 return nullptr;
             }
         }
@@ -152,7 +147,7 @@ struct champ
             auto fst = node->collisions();
             auto lst = fst + node->collision_count();
             for (; fst != lst; ++fst)
-                if (Equal{}(*fst, std::move(v)))
+                if (Equal{}(*fst, v))
                     return {
                         node_t::copy_collision_replace(node, fst, std::move(v)),
                         false

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -1,0 +1,158 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+
+#include <immer/detail/combine_standard_layout.hpp>
+#include <immer/detail/util.hpp>
+#include <immer/detail/hamts/bits.hpp>
+
+#include <cassert>
+
+#ifdef NDEBUG
+#define IMMER_HAMTS_TAGGED_NODE 0
+#else
+#define IMMER_HAMTS_TAGGED_NODE 1
+#endif
+
+namespace immer {
+namespace detail {
+namespace hamts {
+
+template <typename T,
+          typename Hash,
+          typename Equal,
+          typename MemoryPolicy,
+          bits_t B>
+struct champ
+{
+    struct node;
+    static constexpr auto bits      = B;
+
+    using node_t      = node;
+    using memory      = MemoryPolicy;
+    using heap_policy = typename memory::heap;
+    using heap        = typename heap_policy::type;
+    using transience  = typename memory::transience_t;
+    using refs_t      = typename memory::refcount;
+    using ownee_t     = typename transience::ownee;
+    using edit_t      = typename transience::edit;
+    using value_t     = T;
+
+    struct node
+    {
+        enum class kind_t
+        {
+            leaf,
+            inner
+        };
+
+        struct leaf_t
+        {
+            aligned_storage_for<T> buffer;
+        };
+
+        using values_t = combine_standard_layout_t<
+            leaf_t, refs_t>;
+
+        struct inner_t
+        {
+            bitmap_t  map_children;
+            bitmap_t  map_values;
+            values_t* values;
+            aligned_storage_for<node_t*> buffer;
+        };
+
+        union data_t
+        {
+            inner_t inner;
+            leaf_t  leaf;
+        };
+
+        struct impl_data_t
+        {
+#if IMMER_HAMTS_TAGGED_NODE
+            kind_t kind;
+#endif
+            data_t data;
+        };
+
+        using impl_t = combine_standard_layout_t<
+            impl_data_t, refs_t>;
+
+        impl_t impl;
+
+        constexpr static std::size_t sizeof_values_n(count_t count)
+        {
+            return immer_offsetof(values_t, d.buffer)
+                + sizeof(leaf_t::buffer) * count;
+        }
+
+        constexpr static std::size_t sizeof_leaf_n(count_t count)
+        {
+            return immer_offsetof(impl_t, d.data.leaf.buffer)
+                + sizeof(leaf_t::buffer) * count;
+        }
+
+        constexpr static std::size_t sizeof_inner_n(count_t count)
+        {
+            return immer_offsetof(impl_t, d.data.inner.buffer)
+                + sizeof(inner_t::buffer) * count;
+        }
+
+        static node_t* make_inner_n(count_t n)
+        {
+            assert(n <= branches<B>);
+            auto m = heap::allocate(sizeof_inner_n(n));
+            auto p = new (m) node_t;
+            p->impl.d.data.inner.values = nullptr;
+#if IMMER_HAMTS_TAGGED_NODE
+            p->impl.d.kind = node_t::kind_t::inner;
+#endif
+            return p;
+        }
+    };
+
+    node_t* root;
+    size_t  size;
+
+    static const champ empty;
+
+    template <typename K>
+    T* get(const K& k) const
+    {
+        return nullptr;
+    }
+
+    champ add(T v) const
+    {
+        return *this;
+    }
+};
+
+template <typename T, typename H, typename Eq, typename MP, bits_t B>
+const champ<T, H, Eq, MP, B> champ<T, H, Eq, MP, B>::empty = {
+    node_t::make_inner_n(0),
+    0,
+};
+
+} // namespace hamts
+} // namespace detail
+} // namespace immer

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -34,6 +34,8 @@ template <typename T,
           bits_t B>
 struct champ
 {
+    static_assert(branches<B> <= sizeof(bitmap_t) * 8, "");
+
     static constexpr auto bits = B;
 
     using node_t = cnode<T, Hash, Equal, MemoryPolicy, B>;

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -112,6 +112,26 @@ struct champ
         }
     }
 
+    template <typename Fn>
+    void for_each_chunk(Fn&& fn) const
+    {
+        for_each_chunk_traversal(root, 0, fn);
+    }
+
+    template <typename Fn>
+    void for_each_chunk_traversal(node_t* node, count_t depth, Fn&& fn) const
+    {
+        if (depth < max_depth<B>) {
+            fn(node->values(), node->values() + popcount(node->datamap()));
+            auto fst = node->children();
+            auto lst = fst + popcount(node->nodemap());
+            for (; fst != lst; ++fst)
+                for_each_chunk_traversal(*fst, depth + 1, fn);
+        } else {
+            fn(node->collisions(), node->collisions() + node->collision_count());
+        }
+    }
+
     template <typename K>
     const T* get(const K& k) const
     {

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -275,8 +275,9 @@ struct champ
                 case sub_result::nothing:
                     return {};
                 case sub_result::singleton:
-                    return popcount(node->datamap()) == 0 &&
-                           popcount(node->nodemap()) == 1
+                    return node->datamap() == 0 &&
+                           popcount(node->nodemap()) == 1 &&
+                           shift > 0
                         ? result
                         : node_t::copy_inner_replace_inline(
                             node, bit, offset, *result.data.singleton);

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -123,8 +123,8 @@ struct champ
         }
     }
 
-    template <typename K>
-    const T* get(const K& k) const
+    template <typename Project, typename Default, typename K>
+    decltype(auto) get(const K& k) const
     {
         auto node = root;
         auto hash = Hash{}(k);
@@ -138,19 +138,19 @@ struct champ
                 auto offset = popcount(node->datamap() & (bit - 1));
                 auto val    = node->values() + offset;
                 if (Equal{}(*val, k))
-                    return val;
+                    return Project{}(*val);
                 else
-                    return nullptr;
+                    return Default{}();
             } else {
-                return nullptr;
+                return Default{}();
             }
         }
         auto fst = node->collisions();
         auto lst = fst + node->collision_count();
         for (; fst != lst; ++fst)
             if (Equal{}(*fst, k))
-                return fst;
-        return nullptr;
+                return Project{}(*fst);
+        return Default{}();
     }
 
     std::pair<node_t*, bool>

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -329,6 +329,47 @@ struct champ
             IMMER_UNREACHABLE;
         }
     }
+
+    bool equals(const champ& other) const
+    {
+        return size == other.size && equals_tree(root, other.root, 0);
+    }
+
+    static bool equals_tree(const node_t* a, const node_t* b, count_t depth)
+    {
+        if (a == b)
+            return true;
+        else if (depth == max_depth<B>) {
+            auto nv = a->collision_count();
+            return nv == b->collision_count() &&
+                equals_collisions(a->collisions(), b->collisions(), nv);
+        } else {
+            if (a->nodemap() != b->nodemap() ||
+                a->datamap() != b->datamap())
+                return false;
+            auto n = popcount(a->nodemap());
+            for (auto i = count_t{}; i < n; ++i)
+                if (!equals_tree(a->children()[i], b->children()[i], depth + 1))
+                    return false;
+            auto nv = popcount(a->datamap());
+            return equals_values(a->values(), b->values(), nv);
+        }
+    }
+
+    static bool equals_values(const T* a, const T* b, count_t n)
+    {
+        return std::equal(a, a + n, b, Equal{});
+    }
+
+    static bool equals_collisions(const T* a, const T* b, count_t n)
+    {
+        auto ae = a + n;
+        auto be = b + n;
+        for (; a != ae; ++a)
+            if (std::find(b, be, *a) == be)
+                return false;
+        return true;
+    }
 };
 
 template <typename T, typename H, typename Eq, typename MP, bits_t B>

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -21,7 +21,7 @@
 #pragma once
 
 #include <immer/config.hpp>
-#include <immer/detail/hamts/cnode.hpp>
+#include <immer/detail/hamts/node.hpp>
 
 namespace immer {
 namespace detail {
@@ -38,7 +38,7 @@ struct champ
 
     static constexpr auto bits = B;
 
-    using node_t = cnode<T, Hash, Equal, MemoryPolicy, B>;
+    using node_t = node<T, Hash, Equal, MemoryPolicy, B>;
 
     node_t* root;
     size_t  size;

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -122,11 +122,16 @@ struct champ
     void for_each_chunk_traversal(node_t* node, count_t depth, Fn&& fn) const
     {
         if (depth < max_depth<B>) {
-            fn(node->values(), node->values() + popcount(node->datamap()));
-            auto fst = node->children();
-            auto lst = fst + popcount(node->nodemap());
-            for (; fst != lst; ++fst)
-                for_each_chunk_traversal(*fst, depth + 1, fn);
+            auto datamap = node->datamap();
+            if (datamap)
+                fn(node->values(), node->values() + popcount(datamap));
+            auto nodemap = node->nodemap();
+            if (nodemap) {
+                auto fst = node->children();
+                auto lst = fst + popcount(nodemap);
+                for (; fst != lst; ++fst)
+                    for_each_chunk_traversal(*fst, depth + 1, fn);
+            }
         } else {
             fn(node->collisions(), node->collisions() + node->collision_count());
         }

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -281,8 +281,13 @@ struct champ
                         : node_t::copy_inner_replace_inline(
                             node, bit, offset, *result.data.singleton);
                 case sub_result::tree:
-                    return node_t::copy_inner_replace(node, offset,
-                                                     result.data.tree);
+                    try {
+                        return node_t::copy_inner_replace(node, offset,
+                                                          result.data.tree);
+                    } catch (...) {
+                        node_t::delete_deep_shift(result.data.tree, shift + B);
+                        throw;
+                    }
                 }
             } else if (node->datamap() & bit) {
                 auto offset = popcount(node->datamap() & (bit - 1));

--- a/immer/detail/hamts/champ_iterator.hpp
+++ b/immer/detail/hamts/champ_iterator.hpp
@@ -1,0 +1,156 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+
+#include <immer/detail/hamts/champ.hpp>
+#include <immer/detail/iterator_facade.hpp>
+
+namespace immer {
+namespace detail {
+namespace hamts {
+
+template <typename T, typename Hash, typename Eq, typename MP, bits_t B>
+struct champ_iterator
+    : iterator_facade<champ_iterator<T, Hash, Eq, MP, B>,
+                      std::forward_iterator_tag,
+                      T,
+                      const T&>
+{
+    using tree_t = champ<T, Hash, Eq, MP, B>;
+    using node_t = typename tree_t::node_t;
+
+    struct end_t {};
+
+    champ_iterator() = default;
+
+    champ_iterator(const tree_t& v)
+        : cur_   { v.root->values()  }
+        , end_   { v.root->values() + popcount(v.root->datamap()) }
+        , depth_ { 0 }
+    {
+        path_[0] = &v.root;
+        ensure_valid_();
+    }
+
+    champ_iterator(const tree_t& v, end_t)
+        : cur_   { nullptr }
+        , end_   { nullptr }
+        , depth_ { 0 }
+    {
+        path_[0] = &v.root;
+    }
+
+    champ_iterator(const champ_iterator& other)
+        : cur_   { other.cur_ }
+        , end_   { other.end_ }
+        , depth_ { other.depth_ }
+    {
+        std::copy(other.path_, other.path_ + depth_ + 1, path_);
+    }
+
+private:
+    friend iterator_core_access;
+
+    T* cur_;
+    T* end_;
+    count_t depth_;
+    node_t* const* path_[max_depth<B> + 1];
+
+    void increment()
+    {
+        ++cur_;
+        ensure_valid_();
+    }
+
+    bool step_down()
+    {
+        if (depth_ < max_depth<B>) {
+            auto parent = *path_[depth_];
+            if (parent->nodemap()) {
+                ++depth_;
+                path_[depth_] = parent->children();
+                auto child = *path_[depth_];
+                if (depth_ < max_depth<B>) {
+                    cur_ = child->values();
+                    end_ = cur_ + popcount(child->datamap());
+                } else {
+                    cur_ = child->collisions();
+                    end_ = cur_ + child->collision_count();
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool step_right()
+    {
+        while (depth_ > 0) {
+            auto parent = *path_[depth_ - 1];
+            auto last   = parent->children() + popcount(parent->nodemap());
+            auto next   = path_[depth_] + 1;
+            if (next < last) {
+                path_[depth_] = next;
+                auto child = *path_[depth_];
+                if (depth_ < max_depth<B>) {
+                    cur_ = child->values();
+                    end_ = cur_ + popcount(child->datamap());
+                } else {
+                    cur_ = child->collisions();
+                    end_ = cur_ + child->collision_count();
+                }
+                return true;
+            }
+            -- depth_;
+        }
+        return false;
+    }
+
+    void ensure_valid_()
+    {
+        assert(cur_ != nullptr);
+        while (cur_ == end_) {
+            while (step_down())
+                if (cur_ != end_)
+                    return;
+            if (!step_right()) {
+                // end of sequence
+                assert(depth_ == 0);
+                cur_ = end_ = nullptr;
+                return;
+            }
+        }
+    }
+
+    bool equal(const champ_iterator& other) const
+    {
+        return cur_ == other.cur_;
+    }
+
+    const T& dereference() const
+    {
+        return *cur_;
+    }
+};
+
+} // namespace hamts
+} // namespace detail
+} // namespace immer

--- a/immer/detail/hamts/champ_iterator.hpp
+++ b/immer/detail/hamts/champ_iterator.hpp
@@ -126,7 +126,6 @@ private:
 
     void ensure_valid_()
     {
-        assert(cur_ != nullptr);
         while (cur_ == end_) {
             while (step_down())
                 if (cur_ != end_)

--- a/immer/detail/hamts/cnode.hpp
+++ b/immer/detail/hamts/cnode.hpp
@@ -196,7 +196,7 @@ struct cnode
 
     static node_t* make_inner_n(count_t n, count_t nv)
     {
-        assert(nv < branches<B>);
+        assert(nv <= branches<B>);
         auto p = make_inner_n(n);
         if (nv) {
             p->impl.d.data.inner.values =

--- a/immer/detail/hamts/cnode.hpp
+++ b/immer/detail/hamts/cnode.hpp
@@ -128,31 +128,37 @@ struct cnode
 
     auto values()
     {
+        assert(kind() == kind_t::inner);
         return (T*) &impl.d.data.inner.values->d.buffer;
     }
 
     auto children()
     {
+        assert(kind() == kind_t::inner);
         return (node_t**) &impl.d.data.inner.buffer;
     }
 
     auto datamap() const
     {
+        assert(kind() == kind_t::inner);
         return impl.d.data.inner.datamap;
     }
 
     auto nodemap() const
     {
+        assert(kind() == kind_t::inner);
         return impl.d.data.inner.nodemap;
     }
 
     auto collision_count() const
     {
+        assert(kind() == kind_t::collision);
         return impl.d.data.collision.count;
     }
 
     T* collisions()
     {
+        assert(kind() == kind_t::collision);
         return (T*)&impl.d.data.collision.buffer;
     }
 
@@ -169,11 +175,217 @@ struct cnode
         assert(n <= branches<B>);
         auto m = heap::allocate(sizeof_inner_n(n));
         auto p = new (m) node_t;
-        p->impl.d.data.inner.values = nullptr;
 #if IMMER_HAMTS_TAGGED_NODE
         p->impl.d.kind = node_t::kind_t::inner;
 #endif
+        p->impl.d.data.inner.nodemap = 0;
+        p->impl.d.data.inner.datamap = 0;
+        p->impl.d.data.inner.values  = nullptr;
         return p;
+    }
+
+    static node_t* make_inner_n(count_t n, values_t* values)
+    {
+        assert(values);
+        auto p = make_inner_n(n);
+        p->impl.d.data.inner.values = values;
+        refs(values).inc();
+        return p;
+    }
+
+    static node_t* make_inner_n(count_t n, count_t nv)
+    {
+        assert(nv > 0);
+        assert(nv < branches<B>);
+        auto p = make_inner_n(n);
+        p->impl.d.data.inner.values =
+            new (heap::allocate(sizeof_values_n(nv))) values_t{};
+        return p;
+    }
+
+    static node_t* make_inner_n(count_t n, node_t* child)
+    {
+        assert(n >= 1);
+        auto p = make_inner_n(n);
+        p->children()[0] = child;
+        return p;
+    }
+
+    static node_t* make_inner_n(count_t n,
+                                count_t idx1, T x1,
+                                count_t idx2, T x2)
+    {
+        auto p = make_inner_n(n, 2);
+        p->impl.d.data.inner.datamap = (1 << idx1) | (1 << idx2);
+        if (idx1 < idx2) {
+            p->values()[0] = std::move(x1);
+            p->values()[1] = std::move(x2);
+        } else {
+            assert(idx1 > idx2);
+            p->values()[0] = std::move(x2);
+            p->values()[1] = std::move(x1);
+        }
+        return p;
+    }
+
+    static node_t* make_collision_n(count_t n)
+    {
+        assert(n <= branches<B>);
+        auto m = heap::allocate(sizeof_collision_n(n));
+        auto p = new (m) node_t;
+#if IMMER_HAMTS_TAGGED_NODE
+        p->impl.d.kind = node_t::kind_t::collision;
+#endif
+        p->impl.d.data.collision.count = n;
+        return p;
+    }
+
+    static node_t* make_collision(T v1, T v2)
+    {
+        auto m = heap::allocate(sizeof_collision_n(2));
+        auto p = new (m) node_t;
+        auto cols = p->collisions();
+#if IMMER_HAMTS_TAGGED_NODE
+        p->impl.d.kind = node_t::kind_t::collision;
+#endif
+        p->impl.d.data.collision.count = 2;
+        cols[0] = std::move(v1);
+        cols[1] = std::move(v2);
+        return p;
+    }
+
+    static node_t* copy_collision_insert(node_t* src, T v)
+    {
+        assert(src->kind() == kind_t::collision);
+        auto n    = src->collision_count();
+        auto dst  = make_collision_n(n);
+        auto srcp = src->collisions();
+        auto dstp = dst->collisions();
+        new (dstp) T{std::move(v)};
+        std::uninitialized_copy(srcp, srcp + n, dstp + 1);
+        return dst;
+    }
+
+    static node_t* copy_collision_replace(node_t* src, T* pos, T v)
+    {
+        assert(src->kind() == kind_t::collision);
+        auto n    = src->collision_count();
+        auto dst  = make_collision_n(n);
+        auto srcp = src->collisions();
+        auto dstp = dst->collisions();
+        assert(pos >= srcp && pos < srcp + n);
+        new (dstp) T{std::move(v)};
+        dstp = std::uninitialized_copy(srcp, pos, dstp + 1);
+        std::uninitialized_copy(pos + 1, srcp + n, dstp);
+        return dst;
+    }
+
+    static node_t* copy_inner_replace(node_t* src,
+                                      count_t offset, node_t* child)
+    {
+        assert(src->kind() == kind_t::inner);
+        auto n    = popcount(src->nodemap());
+        auto dst  = make_inner_n(n, src->impl.d.data.inner.values);
+        auto srcp = src->children();
+        auto dstp = dst->children();
+        dst->impl.d.data.inner.datamap = src->datamap();
+        dst->impl.d.data.inner.nodemap = src->nodemap();
+        std::uninitialized_copy(srcp, srcp + n, dstp);
+        inc_nodes(srcp, n);
+        srcp[offset]->dec_unsafe();
+        dstp[offset] = child;
+        return dst;
+    }
+
+    static node_t* copy_inner_replace_value(node_t* src,
+                                            count_t offset, T v)
+    {
+        assert(src->kind() == kind_t::inner);
+        assert(offset < popcount(src->datamap()));
+        auto n    = popcount(src->nodemap());
+        auto nv   = popcount(src->datamap());
+        auto dst  = make_inner_n(n, nv);
+        dst->impl.d.data.inner.datamap = src->datamap();
+        dst->impl.d.data.inner.nodemap = src->nodemap();
+        inc_nodes(src->children(), n);
+        std::uninitialized_copy(
+            src->children(), src->children() + n, dst->children());
+        std::uninitialized_copy(
+            src->values(), src->values() + nv, dst->values());
+        dst->values()[offset] = std::move(v);
+        return dst;
+    }
+
+    static node_t* copy_inner_replace_merged(
+        node_t* src, bitmap_t bit, count_t voffset, node_t* node)
+    {
+        assert(src->kind() == kind_t::inner);
+        assert(!(src->nodemap() & bit));
+        assert(src->datamap() & bit);
+        assert(voffset == popcount(src->datamap() & (bit - 1)));
+        auto n       = popcount(src->nodemap());
+        auto nv      = popcount(src->datamap());
+        auto dst     = make_inner_n(n + 1, nv - 1);
+        auto noffset = popcount(src->nodemap() & (bit - 1));
+        dst->impl.d.data.inner.datamap = src->datamap() & ~bit;
+        dst->impl.d.data.inner.nodemap = src->nodemap() | bit;
+        inc_nodes(src->children(), n);
+        std::uninitialized_copy(
+            src->children(), src->children() + noffset,
+            dst->children());
+        std::uninitialized_copy(
+            src->children() + noffset + 1, src->children() + n,
+            dst->children() + noffset + 1);
+        std::uninitialized_copy(
+            src->values(), src->values() + voffset,
+            dst->values());
+        std::uninitialized_copy(
+            src->values() + noffset + 1, src->values() + nv,
+            dst->values() + noffset + 1);
+        dst->children()[noffset] = node;
+        return dst;
+    }
+
+    static node_t* copy_inner_insert_value(node_t* src, bitmap_t bit, T v)
+    {
+        assert(src->kind() == kind_t::inner);
+        auto n      = popcount(src->nodemap());
+        auto nv     = popcount(src->datamap());
+        auto offset = popcount(src->datamap() & (bit - 1));
+        auto dst    = make_inner_n(n, nv + 1);
+        dst->impl.d.data.inner.datamap = src->datamap() | bit;
+        dst->impl.d.data.inner.nodemap = src->nodemap();
+        inc_nodes(src->children(), n);
+        std::uninitialized_copy(
+            src->children(), src->children() + n, dst->children());
+        std::uninitialized_copy(
+            src->values(), src->values() + offset, dst->values());
+        std::uninitialized_copy(
+            src->values() + offset, src->values() + nv,
+            dst->values() + offset + 1);
+        dst->values()[offset] = std::move(v);
+        return dst;
+    }
+
+    static node_t* make_merged(shift_t shift,
+                               T v1, hash_t hash1,
+                               T v2, hash_t hash2)
+    {
+        if (shift == max_shift<B>) {
+            return make_collision(std::move(v1), std::move(v2));
+        } else {
+            auto idx1 = hash1 & (mask<B> << shift);
+            auto idx2 = hash2 & (mask<B> << shift);
+            if (idx1 == idx2) {
+                return make_inner_n(1, make_merged(shift + B,
+                                                   std::move(v1), hash1,
+                                                   std::move(v2), hash2));
+            } else {
+                return make_inner_n(0,
+                                    idx1 >> shift, std::move(v1),
+                                    idx2 >> shift, std::move(v2));
+            }
+        }
     }
 
     node_t* inc()
@@ -191,24 +403,32 @@ struct cnode
     bool dec() const { return refs(this).dec(); }
     void dec_unsafe() const { refs(this).dec_unsafe(); }
 
+    static void inc_nodes(node_t** p, count_t n)
+    {
+        for (auto i = p, e = i + n; i != e; ++i)
+            refs(*i).inc();
+    }
+
     static void delete_values(values_t* p, count_t n)
     {
+        assert(p);
         destroy_n(&p->d.buffer, n);
         heap::deallocate(node_t::sizeof_values_n(n), p);
     }
 
     static void delete_inner(node_t* p)
     {
+        assert(p);
         assert(p->kind() == kind_t::inner);
         auto vp = p->impl.d.data.inner.values;
-        if (node_t::refs(vp).dec()) {
-            auto n = popcount(p->datamap());
-            p->delete_values(vp, n);
-        }
+        if (vp && refs(vp).dec())
+            delete_values(vp, popcount(p->datamap()));
+        heap::deallocate(node_t::sizeof_inner_n(popcount(p->nodemap())), p);
     }
 
     static void delete_collision(node_t* p)
     {
+        assert(p);
         assert(p->kind() == kind_t::collision);
         auto n = p->collision_count();
         destroy_n(p->collisions(), n);

--- a/immer/detail/hamts/cnode.hpp
+++ b/immer/detail/hamts/cnode.hpp
@@ -1,0 +1,221 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+
+#include <immer/detail/combine_standard_layout.hpp>
+#include <immer/detail/util.hpp>
+#include <immer/detail/hamts/bits.hpp>
+
+#include <cassert>
+
+#ifdef NDEBUG
+#define IMMER_HAMTS_TAGGED_NODE 0
+#else
+#define IMMER_HAMTS_TAGGED_NODE 1
+#endif
+
+namespace immer {
+namespace detail {
+namespace hamts {
+
+template <typename T,
+          typename Hash,
+          typename Equal,
+          typename MemoryPolicy,
+          bits_t B>
+struct cnode
+{
+    using node_t      = cnode;
+
+    using memory      = MemoryPolicy;
+    using heap_policy = typename memory::heap;
+    using heap        = typename heap_policy::type;
+    using transience  = typename memory::transience_t;
+    using refs_t      = typename memory::refcount;
+    using ownee_t     = typename transience::ownee;
+    using edit_t      = typename transience::edit;
+    using value_t     = T;
+
+    enum class kind_t
+    {
+        collision,
+        inner
+    };
+
+    struct collision_t
+    {
+        count_t count;
+        aligned_storage_for<T> buffer;
+    };
+
+    struct values_data_t
+    {
+        aligned_storage_for<T> buffer;
+    };
+
+    using values_t = combine_standard_layout_t<
+        values_data_t, refs_t>;
+
+    struct inner_t
+    {
+        bitmap_t  nodemap;
+        bitmap_t  datamap;
+        values_t* values;
+        aligned_storage_for<node_t*> buffer;
+    };
+
+    union data_t
+    {
+        inner_t inner;
+        collision_t collision;
+    };
+
+    struct impl_data_t
+    {
+#if IMMER_HAMTS_TAGGED_NODE
+        kind_t kind;
+#endif
+        data_t data;
+    };
+
+    using impl_t = combine_standard_layout_t<
+        impl_data_t, refs_t>;
+
+    impl_t impl;
+
+    constexpr static std::size_t sizeof_values_n(count_t count)
+    {
+        return immer_offsetof(values_t, d.buffer)
+            + sizeof(values_data_t::buffer) * count;
+    }
+
+    constexpr static std::size_t sizeof_collision_n(count_t count)
+    {
+        return immer_offsetof(impl_t, d.data.collision.buffer)
+            + sizeof(values_data_t::buffer) * count;
+    }
+
+    constexpr static std::size_t sizeof_inner_n(count_t count)
+    {
+        return immer_offsetof(impl_t, d.data.inner.buffer)
+            + sizeof(inner_t::buffer) * count;
+    }
+
+#if IMMER_HAMTS_TAGGED_NODE
+    kind_t kind() const
+    {
+        return impl.d.kind;
+    }
+#endif
+
+    auto values()
+    {
+        return (T*) &impl.d.data.inner.values->d.buffer;
+    }
+
+    auto children()
+    {
+        return (node_t**) &impl.d.data.inner.buffer;
+    }
+
+    auto datamap() const
+    {
+        return impl.d.data.inner.datamap;
+    }
+
+    auto nodemap() const
+    {
+        return impl.d.data.inner.nodemap;
+    }
+
+    auto collision_count() const
+    {
+        return impl.d.data.collision.count;
+    }
+
+    T* collisions()
+    {
+        return (T*)&impl.d.data.collision.buffer;
+    }
+
+    static refs_t& refs(const values_t* x) { return auto_const_cast(get<refs_t>(*x)); }
+    static const ownee_t& ownee(const values_t* x) { return get<ownee_t>(*x); }
+    static ownee_t& ownee(values_t* x) { return get<ownee_t>(*x); }
+
+    static refs_t& refs(const node_t* x) { return auto_const_cast(get<refs_t>(x->impl)); }
+    static const ownee_t& ownee(const node_t* x) { return get<ownee_t>(x->impl); }
+    static ownee_t& ownee(node_t* x) { return get<ownee_t>(x->impl); }
+
+    static node_t* make_inner_n(count_t n)
+    {
+        assert(n <= branches<B>);
+        auto m = heap::allocate(sizeof_inner_n(n));
+        auto p = new (m) node_t;
+        p->impl.d.data.inner.values = nullptr;
+#if IMMER_HAMTS_TAGGED_NODE
+        p->impl.d.kind = node_t::kind_t::inner;
+#endif
+        return p;
+    }
+
+    node_t* inc()
+    {
+        refs(this).inc();
+        return this;
+    }
+
+    const node_t* inc() const
+    {
+        refs(this).inc();
+        return this;
+    }
+
+    bool dec() const { return refs(this).dec(); }
+    void dec_unsafe() const { refs(this).dec_unsafe(); }
+
+    static void delete_values(values_t* p, count_t n)
+    {
+        destroy_n(&p->d.buffer, n);
+        heap::deallocate(node_t::sizeof_values_n(n), p);
+    }
+
+    static void delete_inner(node_t* p)
+    {
+        assert(p->kind() == kind_t::inner);
+        auto vp = p->impl.d.data.inner.values;
+        if (node_t::refs(vp).dec()) {
+            auto n = popcount(p->datamap());
+            p->delete_values(vp, n);
+        }
+    }
+
+    static void delete_collision(node_t* p)
+    {
+        assert(p->kind() == kind_t::collision);
+        auto n = p->collision_count();
+        destroy_n(p->collisions(), n);
+        heap::deallocate(node_t::sizeof_collision_n(n), p);
+    }
+};
+
+} // namespace hamts
+} // namespace detail
+} // namespace immer

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -132,10 +132,22 @@ struct node
         return (T*) &impl.d.data.inner.values->d.buffer;
     }
 
+    auto values() const
+    {
+        assert(kind() == kind_t::inner);
+        return (const T*) &impl.d.data.inner.values->d.buffer;
+    }
+
     auto children()
     {
         assert(kind() == kind_t::inner);
         return (node_t**) &impl.d.data.inner.buffer;
+    }
+
+    auto children() const
+    {
+        assert(kind() == kind_t::inner);
+        return (const node_t* const*) &impl.d.data.inner.buffer;
     }
 
     auto datamap() const
@@ -160,6 +172,12 @@ struct node
     {
         assert(kind() == kind_t::collision);
         return (T*)&impl.d.data.collision.buffer;
+    }
+
+    const T* collisions() const
+    {
+        assert(kind() == kind_t::collision);
+        return (const T*)&impl.d.data.collision.buffer;
     }
 
     static refs_t& refs(const values_t* x) { return auto_const_cast(get<refs_t>(*x)); }

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -228,7 +228,7 @@ struct node
         try {
             new (p->values()) T{std::move(x)};
         } catch (...) {
-            deallocate_inner(p, n);
+            deallocate_inner(p, n, 1);
             throw;
         }
         return p;
@@ -338,7 +338,7 @@ struct node
                 throw;
             }
         } catch (...) {
-            deallocate_collision(dst, n);
+            deallocate_collision(dst, n - 1);
             throw;
         }
         return dst;

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -41,9 +41,9 @@ template <typename T,
           typename Equal,
           typename MemoryPolicy,
           bits_t B>
-struct cnode
+struct node
 {
-    using node_t      = cnode;
+    using node_t      = node;
 
     using memory      = MemoryPolicy;
     using heap_policy = typename memory::heap;

--- a/immer/detail/rbts/operations.hpp
+++ b/immer/detail/rbts/operations.hpp
@@ -83,13 +83,13 @@ struct for_each_chunk_visitor
 
     template <typename Pos, typename Fn>
     friend void visit_inner(this_t, Pos&& pos, Fn&& fn)
-    { pos.each(this_t{}, std::forward<Fn>(fn)); }
+    { pos.each(this_t{}, fn); }
 
     template <typename Pos, typename Fn>
     friend void visit_leaf(this_t, Pos&& pos, Fn&& fn)
     {
         auto data = pos.node()->leaf();
-        std::forward<Fn>(fn)(data, data + pos.count());
+        fn(data, data + pos.count());
     }
 };
 
@@ -99,13 +99,13 @@ struct for_each_chunk_p_visitor
 
     template <typename Pos, typename Fn>
     friend bool visit_inner(this_t, Pos&& pos, Fn&& fn)
-    { return pos.each_pred(this_t{}, std::forward<Fn>(fn)); }
+    { return pos.each_pred(this_t{}, fn); }
 
     template <typename Pos, typename Fn>
     friend bool visit_leaf(this_t, Pos&& pos, Fn&& fn)
     {
         auto data = pos.node()->leaf();
-        return std::forward<Fn>(fn)(data, data + pos.count());
+        return fn(data, data + pos.count());
     }
 };
 
@@ -129,7 +129,7 @@ struct for_each_chunk_left_visitor
     {
         auto data = pos.node()->leaf();
         auto l = pos.index(last);
-        std::forward<Fn>(fn)(data, data + l + 1);
+        fn(data, data + l + 1);
     }
 };
 
@@ -153,7 +153,7 @@ struct for_each_chunk_right_visitor
     {
         auto data = pos.node()->leaf();
         auto f = pos.index(first);
-        std::forward<Fn>(fn)(data + f, data + pos.count());
+        fn(data + f, data + pos.count());
     }
 };
 
@@ -211,7 +211,7 @@ struct for_each_chunk_i_visitor
         if (first < last) {
             auto f = pos.index(first);
             auto l = pos.index(last - 1);
-            std::forward<Fn>(fn)(data + f, data + l + 1);
+            fn(data + f, data + l + 1);
         }
     }
 };
@@ -236,7 +236,7 @@ struct for_each_chunk_p_left_visitor
     {
         auto data = pos.node()->leaf();
         auto l = pos.index(last);
-        return std::forward<Fn>(fn)(data, data + l + 1);
+        return fn(data, data + l + 1);
     }
 };
 
@@ -260,7 +260,7 @@ struct for_each_chunk_p_right_visitor
     {
         auto data = pos.node()->leaf();
         auto f = pos.index(first);
-        return std::forward<Fn>(fn)(data + f, data + pos.count());
+        return fn(data + f, data + pos.count());
     }
 };
 
@@ -320,7 +320,7 @@ struct for_each_chunk_p_i_visitor
         if (first < last) {
             auto f = pos.index(first);
             auto l = pos.index(last - 1);
-            return std::forward<Fn>(fn)(data + f, data + l + 1);
+            return fn(data + f, data + l + 1);
         }
         return true;
     }

--- a/immer/detail/rbts/rbtree.hpp
+++ b/immer/detail/rbts/rbtree.hpp
@@ -369,6 +369,13 @@ struct rbtree
         return descend(get_visitor<T>(), index);
     }
 
+    const T& get_check(size_t index) const
+    {
+        if (index >= size)
+            throw std::out_of_range{"index out of range"};
+        return descend(get_visitor<T>(), index);
+    }
+
     const T& front() const
     {
         return get(0);

--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -472,6 +472,13 @@ struct rrbtree
         return descend(get_visitor<T>(), index);
     }
 
+    const T& get_check(size_t index) const
+    {
+        if (index >= size)
+            throw std::out_of_range{"out of range"};
+        return descend(get_visitor<T>(), index);
+    }
+
     const T& front() const
     {
         return get(0);

--- a/immer/detail/util.hpp
+++ b/immer/detail/util.hpp
@@ -124,5 +124,12 @@ template <bool b, typename R=void, typename F1, typename F2>
 auto static_if(F1&& f1, F2&& f2) -> std::enable_if_t<!b, R>
 { return std::forward<F2>(f2)(empty_t{}); }
 
+template <typename T, T value>
+struct constantly
+{
+    template <typename... Args>
+    T operator() (Args&&...) const { return value; }
+};
+
 } // namespace detail
 } // namespace immer

--- a/immer/detail/util.hpp
+++ b/immer/detail/util.hpp
@@ -47,6 +47,13 @@ auto uninitialized_move(Iter1 in1, Iter1 in2, Iter2 out)
                                    out);
 }
 
+template <class T>
+void destroy(T* first, T* last)
+{
+    for (; first != last; ++first)
+        first->~T();
+}
+
 template <class T, class Size>
 void destroy_n(T* p, Size n)
 {

--- a/immer/flex_vector.hpp
+++ b/immer/flex_vector.hpp
@@ -185,12 +185,21 @@ public:
 
     /*!
      * Returns a `const` reference to the element at position `index`.
-     * Undefined for `index >= size()`.
-     * It does not allocate memory and its complexity
-     * is *effectively* @f$ O(1) @f$.
+     * It is undefined when @f$ 0 index \geq size() @f$.  It does not
+     * allocate memory and its complexity is *effectively* @f$ O(1)
+     * @f$.
      */
     reference operator[] (size_type index) const
     { return impl_.get(index); }
+
+    /*!
+     * Returns a `const` reference to the element at position
+     * `index`. It throws an `std::out_of_range` exception when @f$
+     * index \geq size() @f$.  It does not allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     */
+    reference at(size_type index) const
+    { return impl_.get_check(index); }
 
     /*!
      * Returns whether the vectors are equal.

--- a/immer/flex_vector_transient.hpp
+++ b/immer/flex_vector_transient.hpp
@@ -134,11 +134,21 @@ public:
 
     /*!
      * Returns a `const` reference to the element at position `index`.
-     * It does not allocate memory and its complexity is *effectively*
-     * @f$ O(1) @f$.
+     * It is undefined when @f$ 0 index \geq size() @f$.  It does not
+     * allocate memory and its complexity is *effectively* @f$ O(1)
+     * @f$.
      */
     reference operator[] (size_type index) const
     { return impl_.get(index); }
+
+    /*!
+     * Returns a `const` reference to the element at position
+     * `index`. It throws an `std::out_of_range` exception when @f$
+     * index \geq size() @f$.  It does not allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     */
+    reference at(size_type index) const
+    { return impl_.get_check(index); }
 
     /*!
      * Inserts `value` at the end.  It may allocate memory and its

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -35,7 +35,7 @@ template <typename K,
           detail::hamts::bits_t B = default_bits>
 class map
 {
-    using value_t = std::pair<const K, T>;
+    using value_t = std::pair<K, T>;
 
     struct hash_key
     {
@@ -61,7 +61,7 @@ class map
 public:
     using key_type = K;
     using mapped_type = T;
-    using value_type = std::pair<const K, T>;
+    using value_type = std::pair<K, T>;
     using size_type = detail::hamts::size_t;
     using diference_type = std::ptrdiff_t;
     using hasher = Hash;

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -1,0 +1,94 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+
+#include <immer/memory_policy.hpp>
+#include <immer/detail/hamts/champ.hpp>
+
+#include <functional>
+
+namespace immer {
+
+template <typename K,
+          typename T,
+          typename Hash          = std::hash<T>,
+          typename Equal         = std::equal_to<T>,
+          typename MemoryPolicy  = default_memory_policy,
+          detail::hamts::bits_t B = default_bits>
+class map
+{
+    using value_t = std::pair<const K, T>;
+
+    struct hash_key
+    {
+        auto operator() (const value_t& v)
+        { return Hash{}(v.first); }
+
+        auto operator() (const K& v)
+        { return Hash{}(v); }
+    };
+
+    struct equal_key
+    {
+        auto operator() (const value_t& a, const value_t& b)
+        { return Equal{}(a.first, b.first); }
+
+        auto operator() (const value_t& a, const K& b)
+        { return Equal{}(a.first, b); }
+    };
+
+    using impl_t = detail::hamts::champ<
+        value_t, hash_key, equal_key, MemoryPolicy, B>;
+
+public:
+    using key_type = K;
+    using mapped_type = T;
+    using value_type = std::pair<const K, T>;
+    using size_type = detail::hamts::size_t;
+    using diference_type = std::ptrdiff_t;
+    using hasher = Hash;
+    using key_equal = Equal;
+    using reference = const value_type&;
+    using const_reference = const value_type&;
+
+    map() = default;
+
+    /*!
+     * Returns the number of elements in the container.  It does
+     * not allocate memory and its complexity is @f$ O(1) @f$.
+     */
+    size_type size() const { return impl_.size; }
+
+    map insert(value_type v) const
+    { return impl_.add(std::move(v)); }
+
+    size_type count(const K& k) const
+    { return impl_.get(k) ? 1 : 0; }
+
+private:
+    map(impl_t impl)
+        : impl_(std::move(impl))
+    {}
+
+    impl_t impl_ = impl_t::empty;
+};
+
+} // namespace immer

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -22,11 +22,43 @@
 
 #include <immer/memory_policy.hpp>
 #include <immer/detail/hamts/champ.hpp>
+#include <immer/detail/hamts/champ_iterator.hpp>
 
 #include <functional>
 
 namespace immer {
 
+/*!
+ * Immutable unordered mapping of values from type `K` to type `T`.
+ *
+ * @tparam K    The type of the keys.
+ * @tparam T    The type of the values to be stored in the container.
+ * @tparam Hash The type of a function object capable of hashing
+ *              values of type `T`.
+ * @tparam Equal The type of a function object capable of comparing
+ *              values of type `T`.
+ * @tparam MemoryPolicy Memory management policy. See @ref
+ *              memory_policy.
+ *
+ * @rst
+ *
+ * This cotainer provides a good trade-off between cache locality,
+ * search, update performance and structural sharing.  It does so by
+ * storing the data in contiguous chunks of :math:`2^{B}` elements.
+ * When storing big objects, the size of these contiguous chunks can
+ * become too big, damaging performance.  If this is measured to be
+ * problematic for a specific use-case, it can be solved by using a
+ * `immer::box` to wrap the type `T`.
+ *
+ * **Example**
+ *   .. literalinclude:: ../example/set/intro.cpp
+ *      :language: c++
+ *      :start-after: intro/start
+ *      :end-before:  intro/end
+ *
+ * @endrst
+ *
+ */
 template <typename K,
           typename T,
           typename Hash          = std::hash<T>,
@@ -70,6 +102,10 @@ public:
     using reference = const value_type&;
     using const_reference = const value_type&;
 
+    /*!
+     * Default constructor.  It creates a set of `size() == 0`.  It
+     * does not allocate memory and its complexity is @f$ O(1) @f$.
+     */
     map() = default;
 
     /*!
@@ -81,6 +117,11 @@ public:
     map insert(value_type v) const
     { return impl_.add(std::move(v)); }
 
+    /*!
+     * Returns `1` when the key `k` is contained in the map or `0`
+     * otherwise. It won't allocate memory and its complexity is
+     * *effectively* @f$ O(1) @f$.
+     */
     size_type count(const K& k) const
     { return impl_.get(k) ? 1 : 0; }
 

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -49,7 +49,8 @@ class map
     struct equal_key
     {
         auto operator() (const value_t& a, const value_t& b)
-        { return Equal{}(a.first, b.first); }
+        { return Equal{}(a.first, b.first) &&
+                            a.second == b.second; }
 
         auto operator() (const value_t& a, const K& b)
         { return Equal{}(a.first, b); }

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -262,17 +262,6 @@ public:
      * already in the map, it replaces its association in the map.
      * It may allocate memory and its complexity is *effectively* @f$
      * O(1) @f$.
-     *
-     * @rst
-     *
-     * **Example**
-     *   .. literalinclude:: ../example/map/map.cpp
-     *      :language: c++
-     *      :dedent: 8
-     *      :start-after: insert/start
-     *      :end-before:  insert/end
-     *
-     * @endrst
      */
     map insert(value_type value) const
     { return impl_.add(std::move(value)); }
@@ -282,17 +271,6 @@ public:
      * is already in the map, it replaces its association in the map.
      * It may allocate memory and its complexity is *effectively* @f$
      * O(1) @f$.
-     *
-     * @rst
-     *
-     * **Example**
-     *   .. literalinclude:: ../example/map/map.cpp
-     *      :language: c++
-     *      :dedent: 8
-     *      :start-after: set/start
-     *      :end-before:  set/end
-     *
-     * @endrst
      */
     map set(key_type k, mapped_type v) const
     { return impl_.add({std::move(k), std::move(v)}); }
@@ -303,17 +281,6 @@ public:
      * currently associated value for `k` in the map or a default
      * constructed value otherwise. It may allocate memory
      * and its complexity is *effectively* @f$ O(1) @f$.
-     *
-     * @rst
-     *
-     * **Example**
-     *   .. literalinclude:: ../example/map/map.cpp
-     *      :language: c++
-     *      :dedent: 8
-     *      :start-after: update/start
-     *      :end-before:  update/end
-     *
-     * @endrst
      */
     template <typename Fn>
     map update(key_type k, Fn&& fn) const
@@ -327,17 +294,6 @@ public:
      * Returns a map without the key `k`.  If the key is not
      * associated in the map it returns the same map.  It may allocate
      * memory and its complexity is *effectively* @f$ O(1) @f$.
-     *
-     * @rst
-     *
-     * **Example**
-     *   .. literalinclude:: ../example/map/map.cpp
-     *      :language: c++
-     *      :dedent: 8
-     *      :start-after: erase/start
-     *      :end-before:  erase/end
-     *
-     * @endrst
      */
     map erase(const K& k) const
     { return impl_.sub(k); }

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -51,7 +51,7 @@ namespace immer {
  * `immer::box` to wrap the type `T`.
  *
  * **Example**
- *   .. literalinclude:: ../example/set/intro.cpp
+ *   .. literalinclude:: ../example/map/intro.cpp
  *      :language: c++
  *      :start-after: intro/start
  *      :end-before:  intro/end

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -85,6 +85,14 @@ class map
         }
     };
 
+    struct project_value_ptr
+    {
+        const T* operator() (const value_t& v) const noexcept
+        {
+            return &v.second;
+        }
+    };
+
     struct combine_value
     {
         template <typename Kf, typename Tf>
@@ -206,6 +214,40 @@ public:
      */
     const T& at(const K& k) const
     { return impl_.template get<project_value, error_value>(k); }
+
+
+    /*!
+     * Returns a pointer to the value associated with the key `k`.  If
+     * the key is not contained in the map, a `nullptr` is returned.
+     * It does not allocate memory and its complexity is *effectively*
+     * @f$ O(1) @f$.
+     *
+     * @rst
+     *
+     * .. admonition:: Why doesn't this function return an iterator?
+     *
+     *   Associative containers from the C++ standard library provide a
+     *   ``find`` method that returns an iterator pointing to the
+     *   element in the container or ``end()`` when the key is missing.
+     *   In the case of an unordered container, the only meaningful
+     *   thing one may do with it is to compare it with the end, to
+     *   test if the find was succesfull, and dereference it.  This
+     *   comparison is cumbersome compared to testing for a non-empty
+     *   optional value.  Furthermore, for an immutable container,
+     *   returning an iterator would have some additional performance
+     *   cost, with no benefits otherwise.
+     *
+     *   In our opinion, this function should return a
+     *   ``std::optional<const T&>`` but this construction is not valid
+     *   in any current standard.  As a compromise we return a
+     *   pointer, which has similar syntactic properties yet it is
+     *   unfortunatelly unnecessarily unrestricted.
+     *
+     * @endrst
+     */
+    const T* find(const K& k) const
+    { return impl_.template get<project_value_ptr,
+                                detail::constantly<const T*, nullptr>>(k); }
 
     /*!
      * Returns whether the sets are equal.

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -28,6 +28,14 @@
 
 namespace immer {
 
+template <typename K,
+          typename T,
+          typename Hash,
+          typename Equal,
+          typename MemoryPolicy,
+          detail::hamts::bits_t B>
+class map_transient;
+
 /*!
  * Immutable unordered mapping of values from type `K` to type `T`.
  *
@@ -129,6 +137,8 @@ public:
     using iterator         = detail::hamts::champ_iterator<
         value_t, hash_key, equal_key, MemoryPolicy, B>;
     using const_iterator   = iterator;
+
+    using transient_type   = map_transient<K, T, Hash, Equal, MemoryPolicy, B>;
 
     /*!
      * Default constructor.  It creates a set of `size() == 0`.  It
@@ -249,10 +259,21 @@ public:
     map erase(const K& k) const
     { return impl_.sub(k); }
 
+    /*!
+     * Returns an @a transient form of this container, a
+     * `immer::map_transient`.
+     */
+    transient_type transient() const&
+    { return transient_type{ impl_ }; }
+    transient_type transient() &&
+    { return transient_type{ std::move(impl_) }; }
+
     // Semi-private
     const impl_t& impl() const { return impl_; }
 
 private:
+    friend transient_type;
+
     map(impl_t impl)
         : impl_(std::move(impl))
     {}

--- a/immer/map_transient.hpp
+++ b/immer/map_transient.hpp
@@ -1,0 +1,41 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+
+#include <immer/memory_policy.hpp>
+#include <immer/detail/hamts/champ.hpp>
+
+#include <functional>
+
+namespace immer {
+
+/*!
+ * **WORK IN PROGRESS**
+ */
+template <typename K,
+          typename T,
+          typename Hash          = std::hash<K>,
+          typename Equal         = std::equal_to<K>,
+          typename MemoryPolicy  = default_memory_policy,
+          detail::hamts::bits_t B = default_bits>
+class map_transient;
+
+} // namespace immer

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -22,6 +22,7 @@
 
 #include <immer/memory_policy.hpp>
 #include <immer/detail/hamts/champ.hpp>
+#include <immer/detail/hamts/champ_iterator.hpp>
 
 #include <functional>
 
@@ -46,7 +47,24 @@ public:
     using reference = const T&;
     using const_reference = const T&;
 
+    using iterator         = detail::hamts::champ_iterator<T, Hash, Equal,
+                                                         MemoryPolicy, B>;
+    using const_iterator   = iterator;
+
     set() = default;
+
+    /*!
+     * Returns an iterator pointing at the first element of the
+     * collection. It does not allocate memory and its complexity is
+     * @f$ O(1) @f$.
+     */
+    iterator begin() const { return {impl_}; }
+
+    /*!
+     * Returns an iterator pointing just after the last element of the
+     * collection. It does not allocate and its complexity is @f$ O(1) @f$.
+     */
+    iterator end() const { return {impl_, typename iterator::end_t{}}; }
 
     /*!
      * Returns the number of elements in the container.  It does

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -1,0 +1,71 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+
+#include <immer/memory_policy.hpp>
+#include <immer/detail/hamts/champ.hpp>
+
+#include <functional>
+
+namespace immer {
+
+template <typename T,
+          typename Hash          = std::hash<T>,
+          typename Equal         = std::equal_to<T>,
+          typename MemoryPolicy  = default_memory_policy,
+          detail::hamts::bits_t B = default_bits>
+class set
+{
+    using impl_t = detail::hamts::champ<T, Hash, Equal, MemoryPolicy, B>;
+
+public:
+    using key_type = T;
+    using value_type = T;
+    using size_type = detail::hamts::size_t;
+    using diference_type = std::ptrdiff_t;
+    using hasher = Hash;
+    using key_equal = Equal;
+    using reference = const T&;
+    using const_reference = const T&;
+
+    set() = default;
+
+    /*!
+     * Returns the number of elements in the container.  It does
+     * not allocate memory and its complexity is @f$ O(1) @f$.
+     */
+    size_type size() const { return impl_.size; }
+
+    set insert(T v) const
+    { return impl_.add(std::move(v)); }
+
+    size_type count(const T& v) const
+    { return impl_.get(v) ? 1 : 0; }
+
+private:
+    set(impl_t impl)
+        : impl_(std::move(impl))
+    {}
+
+    impl_t impl_ = impl_t::empty;
+};
+
+} // namespace immer

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -57,6 +57,9 @@ public:
     set insert(T v) const
     { return impl_.add(std::move(v)); }
 
+    set erase(const T& v) const
+    { return impl_.sub(v); }
+
     size_type count(const T& v) const
     { return impl_.get(v) ? 1 : 0; }
 

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -112,7 +112,8 @@ public:
      * *effectively* @f$ O(1) @f$.
      */
     size_type count(const T& value) const
-    { return impl_.get(value) ? 1 : 0; }
+    { return impl_.template get<detail::constantly<size_type, 1>,
+                                detail::constantly<size_type, 0>>(value); }
 
     /*!
      * Returns whether the sets are equal.

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -136,17 +136,6 @@ public:
      * Returns a set containing `value`.  If the `value` is already in
      * the set, it returns the same set.  It may allocate memory and
      * its complexity is *effectively* @f$ O(1) @f$.
-     *
-     * @rst
-     *
-     * **Example**
-     *   .. literalinclude:: ../example/set/set.cpp
-     *      :language: c++
-     *      :dedent: 8
-     *      :start-after: insert/start
-     *      :end-before:  insert/end
-     *
-     * @endrst
      */
     set insert(T value) const
     { return impl_.add(std::move(value)); }
@@ -155,17 +144,6 @@ public:
      * Returns a set without `value`.  If the `value` is not in the
      * set it returns the same set.  It may allocate memory and its
      * complexity is *effectively* @f$ O(1) @f$.
-     *
-     * @rst
-     *
-     * **Example**
-     *   .. literalinclude:: ../example/set/set.cpp
-     *      :language: c++
-     *      :dedent: 8
-     *      :start-after: erase/start
-     *      :end-before:  erase/end
-     *
-     * @endrst
      */
     set erase(const T& value) const
     { return impl_.sub(value); }

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -72,6 +72,14 @@ public:
      */
     size_type size() const { return impl_.size; }
 
+    /*!
+     * Returns whether the sets are equal.
+     */
+    bool operator==(const set& other) const
+    { return impl_.equals(other.impl_); }
+    bool operator!=(const set& other) const
+    { return !(*this == other); }
+
     set insert(T v) const
     { return impl_.add(std::move(v)); }
 

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -81,6 +81,9 @@ public:
     size_type count(const T& v) const
     { return impl_.get(v) ? 1 : 0; }
 
+    // Semi-private
+    const impl_t& impl() const { return impl_; }
+
 private:
     set(impl_t impl)
         : impl_(std::move(impl))

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -28,6 +28,13 @@
 
 namespace immer {
 
+template <typename T,
+          typename Hash,
+          typename Equal,
+          typename MemoryPolicy,
+          detail::hamts::bits_t B>
+class set_transient;
+
 /*!
  * Immutable set representing an unordered bag of values.
  *
@@ -80,6 +87,8 @@ public:
     using iterator         = detail::hamts::champ_iterator<T, Hash, Equal,
                                                          MemoryPolicy, B>;
     using const_iterator   = iterator;
+
+    using transient_type   = set_transient<T, Hash, Equal, MemoryPolicy, B>;
 
     /*!
      * Default constructor.  It creates a set of `size() == 0`.  It
@@ -161,10 +170,21 @@ public:
     set erase(const T& value) const
     { return impl_.sub(value); }
 
+    /*!
+     * Returns an @a transient form of this container, a
+     * `immer::set_transient`.
+     */
+    transient_type transient() const&
+    { return transient_type{ impl_ }; }
+    transient_type transient() &&
+    { return transient_type{ std::move(impl_) }; }
+
     // Semi-private
     const impl_t& impl() const { return impl_; }
 
 private:
+    friend transient_type;
+
     set(impl_t impl)
         : impl_(std::move(impl))
     {}

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -28,6 +28,36 @@
 
 namespace immer {
 
+/*!
+ * Immutable set representing an unordered bag of values.
+ *
+ * @tparam T    The type of the values to be stored in the container.
+ * @tparam Hash The type of a function object capable of hashing
+ *              values of type `T`.
+ * @tparam Equal The type of a function object capable of comparing
+ *              values of type `T`.
+ * @tparam MemoryPolicy Memory management policy. See @ref
+ *              memory_policy.
+ *
+ * @rst
+ *
+ * This cotainer provides a good trade-off between cache locality,
+ * membership checks, update performance and structural sharing.  It
+ * does so by storing the data in contiguous chunks of :math:`2^{B}`
+ * elements.  When storing big objects, the size of these contiguous
+ * chunks can become too big, damaging performance.  If this is
+ * measured to be problematic for a specific use-case, it can be
+ * solved by using a `immer::box` to wrap the type `T`.
+ *
+ * **Example**
+ *   .. literalinclude:: ../example/set/intro.cpp
+ *      :language: c++
+ *      :start-after: intro/start
+ *      :end-before:  intro/end
+ *
+ * @endrst
+ *
+ */
 template <typename T,
           typename Hash          = std::hash<T>,
           typename Equal         = std::equal_to<T>,
@@ -51,6 +81,10 @@ public:
                                                          MemoryPolicy, B>;
     using const_iterator   = iterator;
 
+    /*!
+     * Default constructor.  It creates a set of `size() == 0`.  It
+     * does not allocate memory and its complexity is @f$ O(1) @f$.
+     */
     set() = default;
 
     /*!
@@ -73,6 +107,14 @@ public:
     size_type size() const { return impl_.size; }
 
     /*!
+     * Returns `1` when `value` is contained in the set or `0`
+     * otherwise. It won't allocate memory and its complexity is
+     * *effectively* @f$ O(1) @f$.
+     */
+    size_type count(const T& value) const
+    { return impl_.get(value) ? 1 : 0; }
+
+    /*!
      * Returns whether the sets are equal.
      */
     bool operator==(const set& other) const
@@ -80,14 +122,43 @@ public:
     bool operator!=(const set& other) const
     { return !(*this == other); }
 
-    set insert(T v) const
-    { return impl_.add(std::move(v)); }
+    /*!
+     * Returns a set containing `value`.  If the `value` is already in
+     * the set, it returns the same set.  It may allocate memory and
+     * its complexity is *effectively* @f$ O(1) @f$.
+     *
+     * @rst
+     *
+     * **Example**
+     *   .. literalinclude:: ../example/set/set.cpp
+     *      :language: c++
+     *      :dedent: 8
+     *      :start-after: insert/start
+     *      :end-before:  insert/end
+     *
+     * @endrst
+     */
+    set insert(T value) const
+    { return impl_.add(std::move(value)); }
 
-    set erase(const T& v) const
-    { return impl_.sub(v); }
-
-    size_type count(const T& v) const
-    { return impl_.get(v) ? 1 : 0; }
+    /*!
+     * Returns a set without `value`.  If the `value` is not in the
+     * set it returns the same set.  It may allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     *
+     * @rst
+     *
+     * **Example**
+     *   .. literalinclude:: ../example/set/set.cpp
+     *      :language: c++
+     *      :dedent: 8
+     *      :start-after: erase/start
+     *      :end-before:  erase/end
+     *
+     * @endrst
+     */
+    set erase(const T& value) const
+    { return impl_.sub(value); }
 
     // Semi-private
     const impl_t& impl() const { return impl_; }

--- a/immer/set_transient.hpp
+++ b/immer/set_transient.hpp
@@ -1,0 +1,40 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+
+#include <immer/memory_policy.hpp>
+#include <immer/detail/hamts/champ.hpp>
+
+#include <functional>
+
+namespace immer {
+
+/*!
+ * **WORK IN PROGRESS**
+ */
+template <typename T,
+          typename Hash          = std::hash<T>,
+          typename Equal         = std::equal_to<T>,
+          typename MemoryPolicy  = default_memory_policy,
+          detail::hamts::bits_t B = default_bits>
+class set_transient;
+
+} // namespace immer

--- a/immer/vector.hpp
+++ b/immer/vector.hpp
@@ -189,11 +189,21 @@ public:
 
     /*!
      * Returns a `const` reference to the element at position `index`.
-     * It does not allocate memory and its complexity is *effectively*
-     * @f$ O(1) @f$.
+     * It is undefined when @f$ 0 index \geq size() @f$.  It does not
+     * allocate memory and its complexity is *effectively* @f$ O(1)
+     * @f$.
      */
     reference operator[] (size_type index) const
     { return impl_.get(index); }
+
+    /*!
+     * Returns a `const` reference to the element at position
+     * `index`. It throws an `std::out_of_range` exception when @f$
+     * index \geq size() @f$.  It does not allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     */
+    reference at(size_type index) const
+    { return impl_.get_check(index); }
 
     /*!
      * Returns whether the vectors are equal.

--- a/immer/vector_transient.hpp
+++ b/immer/vector_transient.hpp
@@ -124,11 +124,21 @@ public:
 
     /*!
      * Returns a `const` reference to the element at position `index`.
-     * It does not allocate memory and its complexity is *effectively*
-     * @f$ O(1) @f$.
+     * It is undefined when @f$ 0 index \geq size() @f$.  It does not
+     * allocate memory and its complexity is *effectively* @f$ O(1)
+     * @f$.
      */
     reference operator[] (size_type index) const
     { return impl_.get(index); }
+
+    /*!
+     * Returns a `const` reference to the element at position
+     * `index`. It throws an `std::out_of_range` exception when @f$
+     * index \geq size() @f$.  It does not allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     */
+    reference at(size_type index) const
+    { return impl_.get_check(index); }
 
     /*!
      * Inserts `value` at the end.  It may allocate memory and its

--- a/nix/benchmarks.nix
+++ b/nix/benchmarks.nix
@@ -78,4 +78,23 @@ rec {
       license = licenses.mit;
     };
   };
+
+  hash_trie = stdenv.mkDerivation rec {
+    name = "hash_trie-${version}";
+    version = "git-${commit}";
+    commit = "1ce346c74923ba16329332103dc0f425b658c8be";
+    src = fetchFromGitHub {
+      owner = "philsquared";
+      repo = "hash_trie";
+      rev = commit;
+      sha256 = "0rpa1682vm0fvvrs1jr7jdkskcrgkm3qrawrcr7xrmknz5jf0v4l";
+    };
+    dontBuild = true;
+    installPhase = "mkdir -vp $out/include; cp -vr $src/hash_trie.hpp $out/include/";
+    meta = with stdenv.lib; {
+      homepage = "https://github.com/rsms/immutable-cpp";
+      description = "Persistent immutable data structures for C++";
+      license = licenses.mit;
+    };
+  };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
     benchmarks.steady
     benchmarks.chunkedseq
     benchmarks.immutable_cpp
+    benchmarks.hash_trie
     (python.withPackages (ps: [
       ps.sphinx
       docs.breathe

--- a/shell.nix
+++ b/shell.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     pkgconfig
     doxygen
     ninja
+    gdb
+    lldb
     ccache
     boost
     boehmgc

--- a/test/dada.hpp
+++ b/test/dada.hpp
@@ -25,6 +25,7 @@
 #include <array>
 
 #include <immer/detail/rbts/bits.hpp>
+#include <immer/detail/hamts/bits.hpp>
 
 namespace {
 
@@ -180,22 +181,37 @@ struct dadaist : tristan_tzara
 };
 
 template <typename T>
-struct dadaist_vector;
+struct dadaist_wrapper;
 
-using bits_t = immer::detail::rbts::bits_t;
+using rbits_t = immer::detail::rbts::bits_t;
+using hbits_t = immer::detail::rbts::bits_t;
 
-template <template <class, class, bits_t, bits_t> class V,
-          typename T, typename MP, bits_t B, bits_t BL>
-struct dadaist_vector<V<T, MP, B, BL>>
+template <template <class, class, rbits_t, rbits_t> class V,
+          typename T, typename MP, rbits_t B, rbits_t BL>
+struct dadaist_wrapper<V<T, MP, B, BL>>
 {
     using type = V<dadaist<T>, dadaist_memory_policy<MP>, B, BL>;
 };
 
 template <template <class, class> class V,
           typename T, typename MP>
-struct dadaist_vector<V<T, MP>>
+struct dadaist_wrapper<V<T, MP>>
 {
     using type = V<dadaist<T>, dadaist_memory_policy<MP>>;
+};
+
+template <template <class, class, class, class, hbits_t> class V,
+          typename T, typename E, typename H, typename MP, hbits_t B>
+struct dadaist_wrapper<V<T, H, E, MP, B>>
+{
+    using type = V<dadaist<T>, H, E, dadaist_memory_policy<MP>, B>;
+};
+
+template <template <class, class, class, class, class, hbits_t> class V,
+          typename K, typename T, typename E, typename H, typename MP, hbits_t B>
+struct dadaist_wrapper<V<K, T, H, E, MP, B>>
+{
+    using type = V<K, dadaist<T>, H, E, dadaist_memory_policy<MP>, B>;
 };
 
 } // anonymous namespace

--- a/test/dada.hpp
+++ b/test/dada.hpp
@@ -176,6 +176,8 @@ template <typename T>
 struct dadaist : tristan_tzara
 {
     T value;
+
+    dadaist() : value{} {}
     dadaist(T v) : value{std::move(v)} {}
     operator T() const { return value; }
 };

--- a/test/flex_vector/generic.ipp
+++ b/test/flex_vector/generic.ipp
@@ -555,7 +555,7 @@ TEST_CASE("adopt regular vector contents")
 
 TEST_CASE("exception safety relaxed")
 {
-    using dadaist_vector_t = typename dadaist_vector<FLEX_VECTOR_T<unsigned>>::type;
+    using dadaist_vector_t = typename dadaist_wrapper<FLEX_VECTOR_T<unsigned>>::type;
     constexpr auto n = 666u;
 
     SECTION("push back")

--- a/test/flex_vector/generic.ipp
+++ b/test/flex_vector/generic.ipp
@@ -549,7 +549,7 @@ TEST_CASE("adopt regular vector contents")
     for (auto i = 0u; i < n; ++i) {
         v = v.push_back(i);
         auto fv = FLEX_VECTOR_T<unsigned>{v};
-        CHECK_VECTOR_EQUALS_X(v, fv, [] (auto&& v) { return &v; });
+        CHECK_VECTOR_EQUALS_AUX(v, fv, [] (auto&& v) { return &v; });
     }
 }
 

--- a/test/flex_vector/generic.ipp
+++ b/test/flex_vector/generic.ipp
@@ -18,8 +18,9 @@
 // along with immer.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include "../dada.hpp"
-#include "../util.hpp"
+#include "test/dada.hpp"
+#include "test/util.hpp"
+#include "test/transient_tester.hpp"
 
 #include <immer/algorithm.hpp>
 

--- a/test/flex_vector_transient/generic.ipp
+++ b/test/flex_vector_transient/generic.ipp
@@ -115,7 +115,7 @@ TEST_CASE("drop move")
 
 TEST_CASE("exception safety relaxed")
 {
-    using dadaist_vector_t = typename dadaist_vector<FLEX_VECTOR_T<unsigned>>::type;
+    using dadaist_vector_t = typename dadaist_wrapper<FLEX_VECTOR_T<unsigned>>::type;
     constexpr auto n = 667u;
 
     SECTION("push back")

--- a/test/flex_vector_transient/generic.ipp
+++ b/test/flex_vector_transient/generic.ipp
@@ -18,8 +18,9 @@
 // along with immer.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include "../dada.hpp"
-#include "../util.hpp"
+#include "test/dada.hpp"
+#include "test/util.hpp"
+#include "test/transient_tester.hpp"
 
 #include <immer/algorithm.hpp>
 

--- a/test/flex_vector_transient/generic.ipp
+++ b/test/flex_vector_transient/generic.ipp
@@ -80,7 +80,7 @@ TEST_CASE("adopt regular vector contents")
     for (auto i = 0u; i < n; ++i) {
         v = v.push_back(i);
         auto fv = FLEX_VECTOR_TRANSIENT_T<unsigned>{v.transient()};
-        CHECK_VECTOR_EQUALS_X(v, fv, [] (auto&& v) { return &v; });
+        CHECK_VECTOR_EQUALS_AUX(v, fv, [] (auto&& v) { return &v; });
     }
 }
 

--- a/test/map/B3.cpp
+++ b/test/map/B3.cpp
@@ -1,0 +1,29 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <immer/map.hpp>
+
+template <typename K, typename T,
+          typename Hash = std::hash<K>,
+          typename Eq   = std::equal_to<K>>
+using test_map_t = immer::map<K, T, Hash, Eq, immer::default_memory_policy, 3u>;
+
+#define MAP_T test_map_t
+#include "generic.ipp"

--- a/test/map/default.cpp
+++ b/test/map/default.cpp
@@ -1,0 +1,24 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <immer/map.hpp>
+
+#define MAP_T ::immer::map
+#include "generic.ipp"

--- a/test/map/gc.cpp
+++ b/test/map/gc.cpp
@@ -1,0 +1,37 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <immer/map.hpp>
+#include <immer/heap/gc_heap.hpp>
+#include <immer/refcount/no_refcount_policy.hpp>
+
+using gc_memory = immer::memory_policy<
+    immer::heap_policy<immer::gc_heap>,
+    immer::no_refcount_policy,
+    immer::gc_transience_policy,
+    false>;
+
+template <typename K, typename T,
+          typename Hash = std::hash<K>,
+          typename Eq   = std::equal_to<K>>
+using test_map_t = immer::map<K, T, Hash, Eq, gc_memory, 3u>;
+
+#define MAP_T test_map_t
+#include "generic.ipp"

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -1,0 +1,50 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <catch.hpp>
+
+#ifndef MAP_T
+#error "define the map template to use in MAP_T"
+#endif
+
+TEST_CASE("instantiation")
+{
+    SECTION("default")
+    {
+        auto v = MAP_T<int, int>{};
+        CHECK(v.size() == 0u);
+    }
+}
+
+
+TEST_CASE("basic insertion")
+{
+    auto v1 = MAP_T<int, int>{};
+    CHECK(v1.count(42) == 0);
+
+    auto v2 = v1.insert({42, {}});
+    CHECK(v1.count(42) == 0);
+    CHECK(v2.count(42) == 1);
+
+    auto v3 = v2.insert({42, {}});
+    CHECK(v1.count(42) == 0);
+    CHECK(v2.count(42) == 1);
+    CHECK(v3.count(42) == 1);
+};

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -135,6 +135,17 @@ TEST_CASE("at")
     CHECK_THROWS_AS(v.at(1234), std::out_of_range);
 }
 
+TEST_CASE("find")
+{
+    const auto n = 666u;
+    auto v = make_test_map(n);
+    CHECK(*v.find(0) == 0);
+    CHECK(*v.find(42) == 42);
+    CHECK(*v.find(665) == 665);
+    CHECK(v.find(666) == nullptr);
+    CHECK(v.find(1234) == nullptr);
+}
+
 TEST_CASE("equals and setting")
 {
     const auto n = 666u;

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -18,11 +18,74 @@
 // along with immer.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <catch.hpp>
-
 #ifndef MAP_T
 #error "define the map template to use in MAP_T"
+#include <immer/map.hpp>
+#define MAP_T ::immer::map
 #endif
+
+#include "test/util.hpp"
+#include "test/dada.hpp"
+
+#include <catch.hpp>
+
+#include <unordered_set>
+#include <random>
+
+template <typename T=unsigned>
+auto make_generator()
+{
+    auto engine = std::default_random_engine{42};
+    auto dist = std::uniform_int_distribution<T>{};
+    return std::bind(dist, engine);
+}
+
+struct conflictor
+{
+    unsigned v1;
+    unsigned v2;
+
+    bool operator== (const conflictor& x) const
+    { return v1 == x.v1 && v2 == x.v2; }
+};
+
+struct hash_conflictor
+{
+    std::size_t operator() (const conflictor& x) const
+    { return x.v1; }
+};
+
+auto make_values_with_collisions(unsigned n)
+{
+    auto gen = make_generator();
+    auto vals = std::vector<conflictor>{};
+    auto vals_ = std::unordered_set<conflictor, hash_conflictor>{};
+    generate_n(back_inserter(vals), n, [&] {
+        auto newv = conflictor{};
+        do {
+            newv = { unsigned(gen() % (n / 2)), gen() };
+        } while (!vals_.insert(newv).second);
+        return newv;
+    });
+    return vals;
+}
+
+auto make_test_map(unsigned n)
+{
+    auto s = MAP_T<unsigned, unsigned>{};
+    for (auto i = 0u; i < n; ++i)
+        s = s.insert({i, i});
+    return s;
+}
+
+auto make_test_set(const std::vector<conflictor>& vals)
+{
+    auto s = MAP_T<conflictor, unsigned, hash_conflictor>{};
+    auto i = 0u;
+    for (auto&& v : vals)
+        s = s.insert(v, i++);
+    return s;
+}
 
 TEST_CASE("instantiation")
 {
@@ -32,7 +95,6 @@ TEST_CASE("instantiation")
         CHECK(v.size() == 0u);
     }
 }
-
 
 TEST_CASE("basic insertion")
 {
@@ -48,3 +110,107 @@ TEST_CASE("basic insertion")
     CHECK(v2.count(42) == 1);
     CHECK(v3.count(42) == 1);
 };
+
+TEST_CASE("accessor")
+{
+    const auto n = 666u;
+    auto v = make_test_map(n);
+    CHECK(v[0] == 0);
+    CHECK(v[42] == 42);
+    CHECK(v[665] == 665);
+    CHECK(v[666] == 0);
+    CHECK(v[1234] == 0);
+}
+
+TEST_CASE("at")
+{
+    const auto n = 666u;
+    auto v = make_test_map(n);
+    CHECK(v.at(0) == 0);
+    CHECK(v.at(42) == 42);
+    CHECK(v.at(665) == 665);
+    CHECK_THROWS_AS(v.at(666), std::out_of_range);
+    CHECK_THROWS_AS(v.at(1234), std::out_of_range);
+}
+
+TEST_CASE("equals and setting")
+{
+    const auto n = 666u;
+    auto v = make_test_map(n);
+
+    CHECK(v == v);
+    CHECK(v != v.insert({1234, 42}));
+    CHECK(v != v.erase(32));
+    CHECK(v == v.insert(1234).erase(1234));
+    CHECK(v == v.erase(32).insert({32, 32}));
+
+    CHECK(v.set(1234, 42) == v.insert({1234, 42}));
+}
+
+TEST_CASE("iterator")
+{
+    const auto N = 666u;
+    auto v = make_test_map(N);
+
+    SECTION("empty set")
+    {
+        auto s = SET_T<unsigned>{};
+        CHECK(s.begin() == s.end());
+    }
+
+    SECTION("works with range loop")
+    {
+        auto seen = std::unordered_set<unsigned>{};
+        for (const auto& x : v)
+            CHECK(seen.insert(x).second);
+        CHECK(seen.size() == v.size());
+    }
+
+    SECTION("works with standard algorithms")
+    {
+        auto s = std::vector<unsigned>(N);
+        std::iota(s.begin(), s.end(), 0u);
+        std::equal(v.begin(), v.end(), s.begin(), s.end());
+    }
+
+    SECTION("iterator and collisions")
+    {
+        auto vals = make_values_with_collisions(N);
+        auto s = make_test_set(vals);
+        auto seen = std::unordered_set<conflictor, hash_conflictor>{};
+        for (const auto& x : s)
+            CHECK(seen.insert(x).second);
+        CHECK(seen.size() == s.size());
+    }
+}
+
+TEST_CASE("accumulate")
+{
+    const auto n = 666u;
+    auto v = make_test_set(n);
+
+    auto expected_n =
+        [] (auto n) {
+            return n * (n - 1) / 2;
+        };
+
+    SECTION("sum collection")
+    {
+        auto acc = [] (unsigned acc, const std::pair<unsigned, unsigned>& x) {
+            return acc + x.first + x.second;
+        }
+        auto sum = immer::accumulate(v, 0u, acc);
+        CHECK(sum == 2 * expected_n(v.size()));
+    }
+
+    SECTION("sum collisions") {
+        auto vals = make_values_with_collisions(n);
+        auto s = make_test_map(vals);
+        auto acc = [] (unsigned r, const std::pair<conflictor, unsigned> x) {
+            return r + x.first.v1 + x.first.v2 + x.second;
+        };
+        auto sum1 = std::accumulate(vals.begin(), vals.end(), 0, acc);
+        auto sum2 = immer::accumulate(s, 0u, acc);
+        CHECK(sum1 == sum2);
+    }
+}

--- a/test/set/B3.cpp
+++ b/test/set/B3.cpp
@@ -1,0 +1,29 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <immer/set.hpp>
+
+template <typename T,
+          typename Hash = std::hash<T>,
+          typename Eq   = std::equal_to<T>>
+using test_set_t = immer::set<T, Hash, Eq, immer::default_memory_policy, 3u>;
+
+#define SET_T test_set_t
+#include "generic.ipp"

--- a/test/set/default.cpp
+++ b/test/set/default.cpp
@@ -1,0 +1,24 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <immer/set.hpp>
+
+#define SET_T ::immer::set
+#include "generic.ipp"

--- a/test/set/gc.cpp
+++ b/test/set/gc.cpp
@@ -1,0 +1,37 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <immer/set.hpp>
+#include <immer/heap/gc_heap.hpp>
+#include <immer/refcount/no_refcount_policy.hpp>
+
+using gc_memory = immer::memory_policy<
+    immer::heap_policy<immer::gc_heap>,
+    immer::no_refcount_policy,
+    immer::gc_transience_policy,
+    false>;
+
+template <typename T,
+          typename Hash = std::hash<T>,
+          typename Eq   = std::equal_to<T>>
+using test_set_t = immer::set<T, Hash, Eq, gc_memory, 3u>;
+
+#define SET_T test_set_t
+#include "generic.ipp"

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -1,0 +1,49 @@
+//
+// immer - immutable data structures for C++
+// Copyright (C) 2016, 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of immer.
+//
+// immer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// immer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with immer.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <catch.hpp>
+
+#ifndef SET_T
+#error "define the set template to use in SET_T"
+#endif
+
+TEST_CASE("instantiation")
+{
+    SECTION("default")
+    {
+        auto v = SET_T<int>{};
+        CHECK(v.size() == 0u);
+    }
+}
+
+TEST_CASE("basic insertion")
+{
+    auto v1 = SET_T<int>{};
+    CHECK(v1.count(42) == 0);
+
+    auto v2 = v1.insert(42);
+    CHECK(v1.count(42) == 0);
+    CHECK(v2.count(42) == 1);
+
+    auto v3 = v2.insert(42);
+    CHECK(v1.count(42) == 0);
+    CHECK(v2.count(42) == 1);
+    CHECK(v3.count(42) == 1);
+};

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -18,11 +18,15 @@
 // along with immer.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <catch.hpp>
-
 #ifndef SET_T
 #error "define the set template to use in SET_T"
+#include <immer/set.hpp>
+#define SET_T ::immer::set
 #endif
+
+#include <catch.hpp>
+
+#include <random>
 
 TEST_CASE("instantiation")
 {
@@ -47,3 +51,27 @@ TEST_CASE("basic insertion")
     CHECK(v2.count(42) == 1);
     CHECK(v3.count(42) == 1);
 };
+
+template <typename T=int>
+auto make_generator()
+{
+    auto engine = std::default_random_engine{42};
+    auto dist = std::uniform_int_distribution<T>{};
+    return std::bind(dist, engine);
+}
+
+TEST_CASE("insert a lot")
+{
+    constexpr auto N = 666u;
+    auto gen = make_generator();
+    auto vals = std::vector<int>{};
+    generate_n(back_inserter(vals), 666u, gen);
+    auto s = SET_T<int>{};
+    for (auto i = 0u; i < N; ++i) {
+        s = s.insert(vals[i]);
+        for (auto j = 0u; j <= i; ++j)
+            CHECK(s.count(vals[j]) == 1);
+        for (auto j = i+1; j < N; ++j)
+            CHECK(s.count(vals[j]) == 0);
+    }
+}

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -289,6 +289,34 @@ TEST_CASE("non default")
     CHECK(v.size() == n);
 }
 
+TEST_CASE("equals")
+{
+    const auto n = 666u;
+    auto v = make_test_set(n);
+
+    CHECK(v == v);
+    CHECK(v != v.insert(1234));
+    CHECK(v == v.erase(1234));
+    CHECK(v == v.insert(1234).erase(1234));
+    CHECK(v == v.erase(64).insert(64));
+    CHECK(v != v.erase(1234).insert(1234));
+}
+
+TEST_CASE("equals collisions")
+{
+    const auto n = 666u;
+    auto vals = make_values_with_collisions(n);
+    auto v = make_test_set(vals);
+
+    CHECK(v == v);
+    CHECK(v != v.erase(vals[42]));
+    CHECK(v == v.erase(vals[42]).insert(vals[42]));
+    CHECK(v == v.erase(vals[42]).erase(vals[13])
+          .insert(vals[42]).insert(vals[13]));
+    CHECK(v == v.erase(vals[42]).erase(vals[13])
+          .insert(vals[13]).insert(vals[42]));
+}
+
 TEST_CASE("exception safety")
 {
     constexpr auto n = 2666u;
@@ -331,7 +359,7 @@ TEST_CASE("exception safety")
         IMMER_TRACE_E(d.happenings);
     }
 
-    SECTION("erase collisions")
+    SECTION("erase")
     {
         auto v = dadaist_set_t{};
         auto d = dadaism{};

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -24,7 +24,7 @@
 #define SET_T ::immer::set
 #endif
 
-#include "../util.hpp"
+#include "test/util.hpp"
 
 #include <immer/algorithm.hpp>
 

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -248,3 +248,42 @@ TEST_CASE("iterator")
         CHECK(seen.size() == s.size());
     }
 }
+
+struct non_default
+{
+    unsigned value;
+    non_default() = delete;
+    operator unsigned() const { return value; }
+
+#if IMMER_DEBUG_PRINT
+    friend std::ostream& operator<< (std::ostream& os, non_default x)
+    {
+        os << "ND{" << x.value << "}";
+        return os;
+    }
+#endif
+};
+
+namespace std {
+
+template <>
+struct hash<non_default>
+{
+    std::size_t operator() (const non_default& x)
+    {
+        return std::hash<decltype(x.value)>{}(x.value);
+    }
+};
+
+} // namespace std
+
+TEST_CASE("non default")
+{
+    const auto n = 666u;
+
+    auto v = SET_T<non_default>{};
+    for (auto i = 0u; i < n; ++i)
+        v = v.insert({ i });
+
+    CHECK(v.size() == n);
+}

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -291,7 +291,7 @@ TEST_CASE("non default")
 
 TEST_CASE("exception safety")
 {
-    constexpr auto n = 6666u;
+    constexpr auto n = 2666u;
 
     using dadaist_set_t = typename dadaist_wrapper<SET_T<unsigned>>::type;
     using dadaist_conflictor_set_t = typename dadaist_wrapper<SET_T<conflictor, hash_conflictor>>::type;
@@ -325,6 +325,49 @@ TEST_CASE("exception safety")
                 ++i;
             } catch (dada_error) {}
             for (auto i : test_irange(0u, i))
+                CHECK(v.count({vals[i]}) == 1);
+        }
+        CHECK(d.happenings > 0);
+        IMMER_TRACE_E(d.happenings);
+    }
+
+    SECTION("erase collisions")
+    {
+        auto v = dadaist_set_t{};
+        auto d = dadaism{};
+        for (auto i = 0u; i < n; ++i)
+            v = v.insert({i});
+        for (auto i = 0u; v.size() > 0;) {
+            try {
+                auto s = d.next();
+                v = v.erase({i});
+                ++i;
+            } catch (dada_error) {}
+            for (auto i : test_irange(0u, i))
+                CHECK(v.count({i}) == 0);
+            for (auto i : test_irange(i, n))
+                CHECK(v.count({i}) == 1);
+        }
+        CHECK(d.happenings > 0);
+        IMMER_TRACE_E(d.happenings);
+    }
+
+    SECTION("erase collisisions")
+    {
+        auto vals = make_values_with_collisions(n);
+        auto v = dadaist_conflictor_set_t{};
+        auto d = dadaism{};
+        for (auto i = 0u; i < n; ++i)
+            v = v.insert({vals[i]});
+        for (auto i = 0u; v.size() > 0;) {
+            try {
+                auto s = d.next();
+                v = v.erase({vals[i]});
+                ++i;
+            } catch (dada_error) {}
+            for (auto i : test_irange(0u, i))
+                CHECK(v.count({vals[i]}) == 0);
+            for (auto i : test_irange(i, n))
                 CHECK(v.count({vals[i]}) == 1);
         }
         CHECK(d.happenings > 0);

--- a/test/transient_tester.hpp
+++ b/test/transient_tester.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "dada.hpp"
+
+namespace {
+
+template <typename VP, typename VT>
+struct transient_tester
+{
+    VP vp;
+    VT vt;
+    dadaism d = {};
+    bool transient = false;
+
+    transient_tester(VP vp)
+        : vp{vp}
+        , vt{vp.transient()}
+    {}
+
+    bool step()
+    {
+        auto s = d.next();
+        if (soft_dada()) {
+            auto new_transient = !transient;
+            try {
+                if (new_transient)
+                    vt = vp.transient();
+                else
+                    vp = vt.persistent();
+            } catch (const dada_error&) { return false; }
+            transient = new_transient;
+            return true;
+        } else
+            return false;
+    }
+};
+
+template <typename VP>
+transient_tester<VP, typename VP::transient_type>
+as_transient_tester(VP p)
+{
+    return { std::move(p) };
+}
+
+} // anonymous namespace

--- a/test/util.hpp
+++ b/test/util.hpp
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#include "dada.hpp"
-
 #include <boost/range/irange.hpp>
 #include <boost/range/join.hpp>
 #include <cstddef>
@@ -36,6 +34,28 @@ struct identity_t
         return std::forward<decltype(x)>(x);
     }
 };
+
+template <typename Integer>
+auto test_irange(Integer from, Integer to)
+{
+#if IMMER_SLOW_TESTS
+    return boost::irange(from, to);
+#else
+    if (to - from < Integer{10})
+        return boost::join(
+            boost::irange(Integer{}, Integer{}),
+            boost::join(boost::irange(from, to, 1),
+                        boost::irange(Integer{}, Integer{})));
+    else
+        return boost::join(
+            boost::irange(from, from + Integer{2}),
+            boost::join(
+                boost::irange(from + Integer{2},
+                              to - Integer{2},
+                              (to - from) / Integer{5}),
+                boost::irange(to - Integer{2}, to)));
+#endif
+}
 
 } // anonymous namespace
 
@@ -93,87 +113,3 @@ struct identity_t
 
 #define CHECK_VECTOR_EQUALS(v1, v2)                             \
     CHECK_VECTOR_EQUALS_AUX((v1), (v2), identity_t{})
-
-namespace {
-
-template <typename Integer>
-auto test_irange(Integer from, Integer to)
-{
-#if IMMER_SLOW_TESTS
-    return boost::irange(from, to);
-#else
-    if (to - from < Integer{10})
-        return boost::join(
-            boost::irange(Integer{}, Integer{}),
-            boost::join(boost::irange(from, to, 1),
-                        boost::irange(Integer{}, Integer{})));
-    else
-        return boost::join(
-            boost::irange(from, from + Integer{2}),
-            boost::join(
-                boost::irange(from + Integer{2},
-                              to - Integer{2},
-                              (to - from) / Integer{5}),
-                boost::irange(to - Integer{2}, to)));
-#endif
-}
-
-struct push_back_fn
-{
-    template <typename T, typename U>
-    auto operator() (T&& v, U&& x)
-    {
-        return std::forward<T>(v)
-            .push_back(std::forward<U>(x));
-    }
-};
-
-struct push_front_fn
-{
-    template <typename T, typename U>
-    auto operator() (T&& v, U&& x)
-    {
-        return std::forward<T>(v)
-            .push_front(std::forward<U>(x));
-    }
-};
-
-template <typename VP, typename VT>
-struct transient_tester
-{
-    VP vp;
-    VT vt;
-    dadaism d = {};
-    bool transient = false;
-
-    transient_tester(VP vp)
-        : vp{vp}
-        , vt{vp.transient()}
-    {}
-
-    bool step()
-    {
-        auto s = d.next();
-        if (soft_dada()) {
-            auto new_transient = !transient;
-            try {
-                if (new_transient)
-                    vt = vp.transient();
-                else
-                    vp = vt.persistent();
-            } catch (const dada_error&) { return false; }
-            transient = new_transient;
-            return true;
-        } else
-            return false;
-    }
-};
-
-template <typename VP>
-transient_tester<VP, typename VP::transient_type>
-as_transient_tester(VP p)
-{
-    return { std::move(p) };
-}
-
-} // anonymous namespace

--- a/test/util.hpp
+++ b/test/util.hpp
@@ -46,7 +46,7 @@ struct identity_t
 #endif
 
 #if IMMER_SLOW_TESTS
-#define CHECK_VECTOR_EQUALS_RANGE_X(v1_, first_, last_, xf_)         \
+#define CHECK_VECTOR_EQUALS_RANGE_AUX(v1_, first_, last_, xf_)         \
     [] (auto&& v1, auto&& first, auto&& last, auto&& xf) {           \
         auto size = std::distance(first, last);                      \
         CHECK(static_cast<std::ptrdiff_t>(v1.size()) == size);       \
@@ -56,7 +56,7 @@ struct identity_t
     } (v1_, first_, last_, xf_)                                      \
     // CHECK_EQUALS
 #else
-#define CHECK_VECTOR_EQUALS_RANGE_X(v1_, first_, last_, ...)            \
+#define CHECK_VECTOR_EQUALS_RANGE_AUX(v1_, first_, last_, ...)            \
     [] (auto&& v1, auto&& first, auto&& last, auto&& xf) {              \
         auto size = std::distance(first, last);                         \
         CHECK(static_cast<std::ptrdiff_t>(v1.size()) == size);          \
@@ -83,16 +83,16 @@ struct identity_t
     // CHECK_EQUALS
 #endif // IMMER_SLOW_TESTS
 
-#define CHECK_VECTOR_EQUALS_X(v1_, v2_, ...)                            \
+#define CHECK_VECTOR_EQUALS_AUX(v1_, v2_, ...)                            \
     [] (auto&& v1, auto&& v2, auto&& ...xs) {                           \
-        CHECK_VECTOR_EQUALS_RANGE_X(v1, v2.begin(), v2.end(), xs...);   \
+        CHECK_VECTOR_EQUALS_RANGE_AUX(v1, v2.begin(), v2.end(), xs...);   \
     } (v1_, v2_, __VA_ARGS__)
 
 #define CHECK_VECTOR_EQUALS_RANGE(v1, b, e)                     \
-    CHECK_VECTOR_EQUALS_RANGE_X((v1), (b), (e), identity_t{})
+    CHECK_VECTOR_EQUALS_RANGE_AUX((v1), (b), (e), identity_t{})
 
 #define CHECK_VECTOR_EQUALS(v1, v2)                             \
-    CHECK_VECTOR_EQUALS_X((v1), (v2), identity_t{})
+    CHECK_VECTOR_EQUALS_AUX((v1), (v2), identity_t{})
 
 namespace {
 

--- a/test/util.hpp
+++ b/test/util.hpp
@@ -102,7 +102,7 @@ auto test_irange(Integer from, Integer to)
 #if IMMER_SLOW_TESTS
     return boost::irange(from, to);
 #else
-    if (to - from < Integer{3})
+    if (to - from < Integer{10})
         return boost::join(
             boost::irange(Integer{}, Integer{}),
             boost::join(boost::irange(from, to, 1),

--- a/test/vector/generic.ipp
+++ b/test/vector/generic.ipp
@@ -181,6 +181,12 @@ TEST_CASE("iterator")
     const auto n = 666u;
     auto v = make_test_vector(0, n);
 
+    SECTION("empty vector")
+    {
+        auto v = VECTOR_T<unsigned>{};
+        CHECK(v.begin() == v.end());
+    }
+
     SECTION("works with range loop")
     {
         auto i = 0u;

--- a/test/vector/generic.ipp
+++ b/test/vector/generic.ipp
@@ -417,7 +417,7 @@ TEST_CASE("exception safety")
 {
     constexpr auto n = 666u;
 
-    using dadaist_vector_t = typename dadaist_vector<VECTOR_T<unsigned>>::type;
+    using dadaist_vector_t = typename dadaist_wrapper<VECTOR_T<unsigned>>::type;
 
     SECTION("push back")
     {

--- a/test/vector/generic.ipp
+++ b/test/vector/generic.ipp
@@ -92,6 +92,15 @@ TEST_CASE("back and front")
     CHECK(v.back() == 9);
 }
 
+TEST_CASE("at")
+{
+    auto v = VECTOR_T<unsigned>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    CHECK(v.at(0) == 0);
+    CHECK(v.at(5) == 5);
+    CHECK_THROWS_AS(v.at(10), std::out_of_range);
+    CHECK_THROWS_AS(v.at(11), std::out_of_range);
+}
+
 TEST_CASE("push back one element")
 {
     SECTION("one element")

--- a/test/vector/generic.ipp
+++ b/test/vector/generic.ipp
@@ -18,8 +18,8 @@
 // along with immer.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include "../util.hpp"
-#include "../dada.hpp"
+#include "test/util.hpp"
+#include "test/dada.hpp"
 
 #include <immer/algorithm.hpp>
 

--- a/test/vector_transient/generic.ipp
+++ b/test/vector_transient/generic.ipp
@@ -177,7 +177,7 @@ TEST_CASE("exception safety")
 {
     constexpr auto n = 667u;
 
-    using dadaist_vector_t = typename dadaist_vector<VECTOR_T<unsigned>>::type;
+    using dadaist_vector_t = typename dadaist_wrapper<VECTOR_T<unsigned>>::type;
 
     SECTION("push back")
     {

--- a/test/vector_transient/generic.ipp
+++ b/test/vector_transient/generic.ipp
@@ -18,7 +18,9 @@
 // along with immer.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include "../util.hpp"
+#include "test/util.hpp"
+#include "test/dada.hpp"
+#include "test/transient_tester.hpp"
 
 #include <catch.hpp>
 


### PR DESCRIPTION
Hello y'all from CppCon! :smile: 

#### Summary

This is a first take at persistent hash maps and sets, providing general efficient unordered collections. They are implemented using CHAMP, a variation on Hash Array Mapped Tries's published here [1][2]. The API is fairly complete, but there are some opportunity for tweaks (see discussion in the documentation for `map::find()` for an example). This PR addresses #7

[1] https://michael.steindorfer.name/publications/oopsla15.pdf
[2] https://michael.steindorfer.name/publications/phd-thesis-efficient-immutable-collections.pdf

#### Performance

Insertion, access and iteration (external and internal) has been compared for our `immer::set` against `std::set`, `std::unordered_set`, `boost::flat_set` and @philsquared `hash_trie`. Here are some runs on my machine (2017 X1 Carbon, Debian Sid, compilers from [Nixpkgs](https://github.com/NixOS/nixpkgs/))

- [Clang 4, N=10...10^6](https://public.sinusoid.es/misc/immer/reports/report_3a992eb_ce1_clang%2b%2b_N%3a%2a%3a10%3a10%3a5_s20)
- [Clang 4, N=1000](https://public.sinusoid.es/misc/immer/reports/report_3a992eb_ce1_clang%2b%2b_N%3a1000_s20)
- [GCC 7, N=1000](https://public.sinusoid.es/misc/immer/reports/report_3a992eb_ce1_g%2b%2b_N%3a1000_s20)

As a summary: CHAMP outperforms naive HAMT's in every benchmark. Loops are regular and have decent cache locality, outperforming `unordered_set` on most queries, and being comparable in iteration performance! Updates are predictably more expensive but within sensible ranges. This will be worked on further later...

#### Future work

1. This PR only includes purely persistent updates. Transients will be worked on next.
2. Unlike for vectors, we do not reuse buffers during updates with reference counting. Due to the sparse nature of the data-structure it is less trivial. However, the way I have in mind to support support transient will move us towards adding support for this.
3. Containers in Immer do not define `std::hash`. We should do so. But furthermore, we should provide 3 policies to cache the hashes inside the containers: a) disabled, b) per container, c) per container node. Along these lines, we could experiment with using other basic hashing algorithms other than what provided by the standard library (e.g. Clojure uses Murmur3, but sipHash and other hashes could be considered).