### PR TITLE
Pedantic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 project(immer VERSION 0.4.0)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wno-unused-parameter -Wno-extended-offsetof")
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 set(CMAKE_CXX_EXTENSIONS off)
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/benchmark/set/access.hpp
+++ b/benchmark/set/access.hpp
@@ -62,7 +62,7 @@ auto benchmark_access_std()
             return r;
         });
     };
-};
+}
 
 template <typename Generator, typename Set>
 auto benchmark_access_hamt()
@@ -88,7 +88,7 @@ auto benchmark_access_hamt()
             return r;
         });
     };
-};
+}
 
 
 template <typename Generator, typename Set>
@@ -112,7 +112,7 @@ auto benchmark_access()
             return r;
         });
     };
-};
+}
 
 template <typename Generator, typename Set>
 auto benchmark_bad_access_std()
@@ -134,7 +134,7 @@ auto benchmark_bad_access_std()
             return r;
         });
     };
-};
+}
 
 template <typename Generator, typename Set>
 auto benchmark_bad_access_hamt()
@@ -159,7 +159,7 @@ auto benchmark_bad_access_hamt()
             return r;
         });
     };
-};
+}
 
 
 template <typename Generator, typename Set>
@@ -182,6 +182,6 @@ auto benchmark_bad_access()
             return r;
         });
     };
-};
+}
 
 } // namespace

--- a/benchmark/set/insert.hpp
+++ b/benchmark/set/insert.hpp
@@ -45,7 +45,7 @@ auto benchmark_insert_mut_std()
             return v;
         });
     };
-};
+}
 
 template <typename Generator, typename Set>
 auto benchmark_insert()
@@ -62,6 +62,6 @@ auto benchmark_insert()
             return v;
         });
     };
-};
+}
 
 } // namespace

--- a/benchmark/set/iter.hpp
+++ b/benchmark/set/iter.hpp
@@ -78,7 +78,7 @@ auto benchmark_access_std_iter()
             return c;
         });
     };
-};
+}
 
 template <typename Generator, typename Set>
 auto benchmark_access_reduce()
@@ -98,7 +98,7 @@ auto benchmark_access_reduce()
             return c;
         });
     };
-};
+}
 
 template <typename Generator, typename Set>
 auto benchmark_access_iter()
@@ -118,6 +118,6 @@ auto benchmark_access_iter()
             return c;
         });
     };
-};
+}
 
 } // namespace

--- a/benchmark/vector/access.hpp
+++ b/benchmark/vector/access.hpp
@@ -170,7 +170,7 @@ auto benchmark_access_idx()
             return rr;
         };
     };
-};
+}
 
 template <typename Vektor,
           typename PushFn=push_back_fn>
@@ -231,7 +231,7 @@ auto benchmark_access_random()
             return rr;
         };
     };
-};
+}
 
 template <typename Fn>
 auto benchmark_access_librrb(Fn maker)

--- a/benchmark/vector/assoc.hpp
+++ b/benchmark/vector/assoc.hpp
@@ -85,7 +85,7 @@ auto benchmark_assoc()
             return r;
         });
     };
-};
+}
 
 template <typename Vektor,
           typename PushFn=push_back_fn>
@@ -108,7 +108,7 @@ auto benchmark_assoc_move()
             return r;
         });
     };
-};
+}
 
 template <typename Vektor,
           typename PushFn=push_back_fn,
@@ -133,7 +133,7 @@ auto benchmark_assoc_random()
             return r;
         });
     };
-};
+}
 
 template <typename Vektor,
           typename PushFn=push_back_fn>
@@ -156,7 +156,7 @@ auto benchmark_assoc_mut()
             return r;
         });
     };
-};
+}
 
 template <typename Vektor,
           typename PushFn=push_back_fn>
@@ -180,7 +180,7 @@ auto benchmark_assoc_mut_random()
             return r;
         });
     };
-};
+}
 
 template <typename Fn>
 auto benchmark_assoc_librrb(Fn maker)

--- a/benchmark/vector/concat.hpp
+++ b/benchmark/vector/concat.hpp
@@ -42,7 +42,7 @@ auto benchmark_concat()
             return v + v;
         });
     };
-};
+}
 
 template <typename Fn>
 auto benchmark_concat_librrb(Fn maker)
@@ -77,7 +77,7 @@ auto benchmark_concat_incr()
                     return r;
                 });
         };
-};
+}
 
 template <typename Vektor>
 auto benchmark_concat_incr_mut()
@@ -98,7 +98,7 @@ auto benchmark_concat_incr_mut()
                 return r;
             });
         };
-};
+}
 
 template <typename Vektor>
 auto benchmark_concat_incr_mut2()
@@ -129,7 +129,7 @@ auto benchmark_concat_incr_mut2()
                 return r;
             });
         };
-};
+}
 
 template <typename Vektor>
 auto benchmark_concat_incr_chunkedseq()
@@ -157,7 +157,7 @@ auto benchmark_concat_incr_chunkedseq()
                 return r;
             });
         };
-};
+}
 
 template <typename Fn>
 auto benchmark_concat_incr_librrb(Fn maker)

--- a/benchmark/vector/drop.hpp
+++ b/benchmark/vector/drop.hpp
@@ -41,7 +41,7 @@ auto benchmark_drop()
                 v.drop(i);
         });
     };
-};
+}
 
 template <typename Vektor,
           typename PushFn=push_back_fn>
@@ -62,7 +62,7 @@ auto benchmark_drop_lin()
             return r;
         });
     };
-};
+}
 
 template <typename Vektor,
           typename PushFn=push_back_fn>
@@ -83,7 +83,7 @@ auto benchmark_drop_move()
             return r;
         });
     };
-};
+}
 
 template <typename Vektor,
           typename PushFn=push_back_fn>
@@ -103,7 +103,7 @@ auto benchmark_drop_mut()
                 v.drop(1);
         });
     };
-};
+}
 
 template <typename Fn>
 auto benchmark_drop_librrb(Fn make)

--- a/benchmark/vector/misc/drop.cpp
+++ b/benchmark/vector/misc/drop.cpp
@@ -37,10 +37,10 @@ extern "C" {
 #if IMMER_BENCHMARK_LIBRRB
 NONIUS_BENCHMARK("librrb", benchmark_drop_librrb(make_librrb_vector))
 NONIUS_BENCHMARK("librrb/F", benchmark_drop_librrb(make_librrb_vector_f))
-NONIUS_BENCHMARK("l/librrb", benchmark_drop_lin_librrb(make_librrb_vector));
-NONIUS_BENCHMARK("l/librrb/F", benchmark_drop_lin_librrb(make_librrb_vector_f));
-NONIUS_BENCHMARK("t/librrb", benchmark_drop_mut_librrb(make_librrb_vector));
-NONIUS_BENCHMARK("t/librrb/F", benchmark_drop_mut_librrb(make_librrb_vector_f));
+NONIUS_BENCHMARK("l/librrb", benchmark_drop_lin_librrb(make_librrb_vector))
+NONIUS_BENCHMARK("l/librrb/F", benchmark_drop_lin_librrb(make_librrb_vector_f))
+NONIUS_BENCHMARK("t/librrb", benchmark_drop_mut_librrb(make_librrb_vector))
+NONIUS_BENCHMARK("t/librrb/F", benchmark_drop_mut_librrb(make_librrb_vector_f))
 #endif
 
 NONIUS_BENCHMARK("flex/4B", benchmark_drop<immer::flex_vector<unsigned,def_memory,4>>())

--- a/benchmark/vector/misc/take.cpp
+++ b/benchmark/vector/misc/take.cpp
@@ -39,10 +39,10 @@ extern "C" {
 #if IMMER_BENCHMARK_LIBRRB
 NONIUS_BENCHMARK("librrb", benchmark_take_librrb(make_librrb_vector))
 NONIUS_BENCHMARK("librrb/F", benchmark_take_librrb(make_librrb_vector_f))
-NONIUS_BENCHMARK("l/librrb", benchmark_take_lin_librrb(make_librrb_vector));
-NONIUS_BENCHMARK("l/librrb/F", benchmark_take_lin_librrb(make_librrb_vector_f));
-NONIUS_BENCHMARK("t/librrb", benchmark_take_mut_librrb(make_librrb_vector));
-NONIUS_BENCHMARK("t/librrb/F", benchmark_take_mut_librrb(make_librrb_vector_f));
+NONIUS_BENCHMARK("l/librrb", benchmark_take_lin_librrb(make_librrb_vector))
+NONIUS_BENCHMARK("l/librrb/F", benchmark_take_lin_librrb(make_librrb_vector_f))
+NONIUS_BENCHMARK("t/librrb", benchmark_take_mut_librrb(make_librrb_vector))
+NONIUS_BENCHMARK("t/librrb/F", benchmark_take_mut_librrb(make_librrb_vector_f))
 #endif
 
 NONIUS_BENCHMARK("vector/4B", benchmark_take<immer::vector<unsigned,def_memory,4>>())

--- a/benchmark/vector/push.hpp
+++ b/benchmark/vector/push.hpp
@@ -40,7 +40,7 @@ auto benchmark_push_mut_std()
             return v;
         });
     };
-};
+}
 
 template <typename Vektor>
 auto benchmark_push_mut()
@@ -58,7 +58,7 @@ auto benchmark_push_mut()
             return v;
         });
     };
-};
+}
 
 template <typename Vektor>
 auto benchmark_push_move()
@@ -76,7 +76,7 @@ auto benchmark_push_move()
             return v;
         });
     };
-};
+}
 
 template <typename Vektor>
 auto benchmark_push()
@@ -94,7 +94,7 @@ auto benchmark_push()
             return v;
         });
     };
-};
+}
 
 auto benchmark_push_librrb(nonius::chronometer meter)
 {

--- a/benchmark/vector/push_front.hpp
+++ b/benchmark/vector/push_front.hpp
@@ -38,7 +38,7 @@ auto bechmark_push_front()
             return v;
         });
     };
-};
+}
 
 auto benchmark_push_front_librrb(nonius::chronometer meter)
 {
@@ -53,6 +53,6 @@ auto benchmark_push_front_librrb(nonius::chronometer meter)
         }
         return v;
     });
-};
+}
 
 } // anonymous namespace

--- a/benchmark/vector/take.hpp
+++ b/benchmark/vector/take.hpp
@@ -41,7 +41,7 @@ auto benchmark_take()
                 v.take(i);
         });
     };
-};
+}
 
 template <typename Vektor,
           typename PushFn=push_back_fn>
@@ -62,7 +62,7 @@ auto benchmark_take_lin()
             return r;
         });
     };
-};
+}
 
 template <typename Vektor,
           typename PushFn=push_back_fn>
@@ -83,7 +83,7 @@ auto benchmark_take_move()
             return r;
         });
     };
-};
+}
 
 template <typename Vektor,
           typename PushFn=push_back_fn>
@@ -103,7 +103,7 @@ auto benchmark_take_mut()
                 v.take(i);
         });
     };
-};
+}
 
 template <typename Fn>
 auto benchmark_take_librrb(Fn make)

--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -238,7 +238,7 @@ struct node
     {
         assert(n <= branches<B>);
         auto mp = heap::allocate(sizeof_inner_r_n(n));
-        auto mr = (void*){};
+        auto mr = static_cast<void*>(nullptr);
         if (embed_relaxed) {
             mr = reinterpret_cast<unsigned char*>(mp) + sizeof_inner_n(n);
         } else {
@@ -280,7 +280,7 @@ struct node
     static node_t* make_inner_r_e(edit_t e)
     {
         auto mp = heap::allocate(max_sizeof_inner_r);
-        auto mr = (void*){};
+        auto mr = static_cast<void*>(nullptr);
         if (embed_relaxed) {
             mr = reinterpret_cast<unsigned char*>(mp) + max_sizeof_inner;
         } else {

--- a/immer/detail/rbts/operations.hpp
+++ b/immer/detail/rbts/operations.hpp
@@ -673,7 +673,7 @@ struct push_tail_mut_visitor
         auto children    = pos.size(idx);
         auto new_idx     = children == size_t{1} << level || level == BL
             ? idx + 1 : idx;
-        auto new_child   = (node_t*){};
+        auto new_child = static_cast<node_t*>(nullptr);
         auto mutate      = Mutating && node->can_mutate(e);
 
         if (new_idx >= branches<B>)
@@ -771,7 +771,7 @@ struct push_tail_visitor
         auto children    = pos.size(idx);
         auto new_idx     = children == size_t{1} << level || level == BL
             ? idx + 1 : idx;
-        auto new_child   = (node_t*){};
+        auto new_child = static_cast<node_t*>(nullptr);
         if (new_idx >= branches<B>)
             return nullptr;
         else if (idx == new_idx) {

--- a/immer/detail/rbts/operations.hpp
+++ b/immer/detail/rbts/operations.hpp
@@ -507,7 +507,7 @@ struct update_visitor
             node_t::delete_leaf(node, pos.count());
             throw;
         }
-    };
+    }
 };
 
 struct dec_visitor
@@ -650,7 +650,7 @@ struct get_mut_visitor
             *location = new_node;
             return new_node->leaf() [pos.index(idx)];
         }
-    };
+    }
 };
 
 template <typename NodeT, bool Mutating = true>
@@ -751,7 +751,7 @@ struct push_tail_mut_visitor
 
     template <typename Pos, typename... Args>
     friend node_t* visit_leaf(this_t, Pos&& pos, edit_t e, node_t* tail, Args&&...)
-    { IMMER_UNREACHABLE; };
+    { IMMER_UNREACHABLE; }
 };
 
 template <typename NodeT>
@@ -824,7 +824,7 @@ struct push_tail_visitor
 
     template <typename Pos, typename... Args>
     friend node_t* visit_leaf(this_t, Pos&& pos, node_t* tail, Args&&...)
-    { IMMER_UNREACHABLE; };
+    { IMMER_UNREACHABLE; }
 };
 
 struct dec_right_visitor
@@ -1024,7 +1024,7 @@ struct slice_right_mut_visitor
             if (Mutating) pos.visit(dec_visitor{});
             return { 0, nullptr, new_tail_size, new_tail };
         }
-    };
+    }
 };
 
 template <typename NodeT, bool Collapse=true>
@@ -1125,7 +1125,7 @@ struct slice_right_visitor
             ? pos.node()->inc()
             : node_t::copy_leaf(pos.node(), new_tail_size);
         return { 0, nullptr, new_tail_size, new_tail };
-    };
+    }
 };
 
 struct dec_left_visitor
@@ -1317,7 +1317,7 @@ struct slice_left_mut_visitor
             if (Mutating) pos.visit(dec_visitor{});
             return { 0, newn };
         }
-    };
+    }
 };
 
 template <typename NodeT, bool Collapse=true>
@@ -1375,7 +1375,7 @@ struct slice_left_visitor
     {
         auto n = node_t::copy_leaf(pos.node(), pos.index(first), pos.count());
         return { 0, n };
-    };
+    }
 };
 
 template <typename Node>

--- a/test/flex_vector/fuzzed-1.cpp
+++ b/test/flex_vector/fuzzed-1.cpp
@@ -183,7 +183,7 @@ TEST_CASE("bug: memory leak because of move update")
         };
         CHECK(run_input(input, sizeof(input)) == 0);
     }
-};
+}
 
 TEST_CASE("non-bug: crash")
 {

--- a/test/flex_vector/fuzzed-2.cpp
+++ b/test/flex_vector/fuzzed-2.cpp
@@ -198,4 +198,4 @@ TEST_CASE("bug: use after free on move-take")
         };
         CHECK(run_input(input, sizeof(input)) == 0);
     }
-};
+}

--- a/test/flex_vector/fuzzed-3.cpp
+++ b/test/flex_vector/fuzzed-3.cpp
@@ -232,4 +232,4 @@ TEST_CASE("bug: concat with moving the right side")
         };
         CHECK(run_input(input, sizeof(input)) == 0);
     }
-};
+}

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -111,7 +111,7 @@ TEST_CASE("basic insertion")
     CHECK(v1.count(42) == 0);
     CHECK(v2.count(42) == 1);
     CHECK(v3.count(42) == 1);
-};
+}
 
 TEST_CASE("accessor")
 {

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -110,7 +110,7 @@ TEST_CASE("basic insertion")
     CHECK(v1.count(42) == 0);
     CHECK(v2.count(42) == 1);
     CHECK(v3.count(42) == 1);
-};
+}
 
 TEST_CASE("insert a lot")
 {


### PR DESCRIPTION
I noticed a few warnings when using immer with the compiler options "-Wextra -pedantic".

- extra semicolons
- use of C compound literals for initializing "auto" pointer variables
- unused arguments
- use of extended offsetof for nested subobjects

I fixed the semicolons and compound literals, but not the unused arguments and a use of extended offsetof.

Regarding the compound literals used for initializing pointer variables I opted for a one-line style that preserved the use of auto and uses static_cast. Personally I would have written the type directly, but it seemed out of place among all the auto variables. I am not sure what is preferred here.

In order to test for the changes I turned up the warning level in the tests.