### PR TITLE
This fixes the problems when using containers in global variables

### DIFF
--- a/immer/heap/thread_local_free_list_heap.hpp
+++ b/immer/heap/thread_local_free_list_heap.hpp
@@ -36,12 +36,12 @@ struct thread_local_free_list_storage
         ~head_t() { Heap::clear(); }
     };
 
-    thread_local static head_t head;
+    static head_t& head()
+    {
+        thread_local static head_t head_{nullptr, 0};
+        return head_;
+    }
 };
-
-template <typename Heap>
-thread_local typename thread_local_free_list_storage<Heap>::head_t
-thread_local_free_list_storage<Heap>::head {nullptr, 0};
 
 } // namespace detail
 


### PR DESCRIPTION
Because of initialization order issues, before this change, it could
happen that a global container using a free_list as part of its memory
policy would be initialized before the state of the free list.  This
fixes the problem, thus addressing issue #37