### PR TITLE
Fix compiler error when iterating a const container

### DIFF
--- a/immer/detail/iterator_facade.hpp
+++ b/immer/detail/iterator_facade.hpp
@@ -93,11 +93,11 @@ protected:
     }
 
 public:
-    ReferenceT operator*() const
+    const T& operator*() const
     {
         return access_t::dereference(derived());
     }
-    PointerT operator->() const
+    const T* operator->() const
     {
         return &access_t::dereference(derived());
     }


### PR DESCRIPTION
Got bitten by a compiler error complaining about conversion from const to non-const here.