### PR TITLE
Use smaller ints for bitmap_t if applicable

### DIFF
--- a/immer/detail/hamts/bits.hpp
+++ b/immer/detail/hamts/bits.hpp
@@ -28,14 +28,25 @@ template <bits_t B>
 struct get_bitmap_type
 {
     static_assert(B < 6u, "B > 6 is not supported.");
-
-    using type = std::uint32_t;
+    using type = std::uint8_t;
 };
 
 template <>
 struct get_bitmap_type<6u>
 {
     using type = std::uint64_t;
+};
+
+template <>
+struct get_bitmap_type<5u>
+{
+    using type = std::uint32_t;
+};
+
+template <>
+struct get_bitmap_type<4u>
+{
+    using type = std::uint16_t;
 };
 
 template <bits_t B, typename T = count_t>
@@ -101,6 +112,16 @@ inline count_t popcount(std::uint64_t x)
 #else
     return popcount_fallback(x);
 #endif
+}
+
+inline count_t popcount(std::uint16_t x)
+{
+    return popcount(static_cast<std::uint32_t>(x));
+}
+
+inline count_t popcount(std::uint8_t x)
+{
+    return popcount(static_cast<std::uint32_t>(x));
 }
 
 } // namespace hamts

--- a/immer/detail/hamts/bits.hpp
+++ b/immer/detail/hamts/bits.hpp
@@ -100,7 +100,7 @@ inline count_t popcount(std::uint64_t x)
 #if IMMER_HAS_BUILTIN_POPCOUNT
 #if defined(_MSC_VER)
 #if defined(_WIN64)
-    return __popcnt64(x);
+    return static_cast<count_t>(__popcnt64(x));
 #else
     // TODO: benchmark against popcount_fallback(std::uint64_t x)
     return popcount(static_cast<std::uint32_t>(x >> 32)) +

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -124,11 +124,11 @@ struct champ
         for (auto i = count_t{}; i < max_depth<B>; ++i) {
             auto bit = bitmap_t{1u} << (hash & mask<B>);
             if (node->nodemap() & bit) {
-                auto offset = popcount(node->nodemap() & (bit - 1));
+                auto offset = popcount(static_cast<bitmap_t>(node->nodemap() & (bit - 1)));
                 node        = node->children()[offset];
                 hash        = hash >> B;
             } else if (node->datamap() & bit) {
-                auto offset = popcount(node->datamap() & (bit - 1));
+                auto offset = popcount(static_cast<bitmap_t>(node->datamap() & (bit - 1)));
                 auto val    = node->values() + offset;
                 if (Equal{}(*val, k))
                     return Project{}(*val);
@@ -163,7 +163,7 @@ struct champ
             auto idx = (hash & (mask<B> << shift)) >> shift;
             auto bit = bitmap_t{1u} << idx;
             if (node->nodemap() & bit) {
-                auto offset = popcount(node->nodemap() & (bit - 1));
+                auto offset = popcount(static_cast<bitmap_t>(node->nodemap() & (bit - 1)));
                 assert(node->children()[offset]);
                 auto result = do_add(
                     node->children()[offset], std::move(v), hash, shift + B);
@@ -176,7 +176,7 @@ struct champ
                     throw;
                 }
             } else if (node->datamap() & bit) {
-                auto offset = popcount(node->datamap() & (bit - 1));
+                auto offset = popcount(static_cast<bitmap_t>(node->datamap() & (bit - 1)));
                 auto val    = node->values() + offset;
                 if (Equal{}(*val, v))
                     return {node_t::copy_inner_replace_value(
@@ -239,7 +239,7 @@ struct champ
             auto idx = (hash & (mask<B> << shift)) >> shift;
             auto bit = bitmap_t{1u} << idx;
             if (node->nodemap() & bit) {
-                auto offset = popcount(node->nodemap() & (bit - 1));
+                auto offset = popcount(static_cast<bitmap_t>(node->nodemap() & (bit - 1)));
                 auto result = do_update<Project, Default, Combine>(
                     node->children()[offset],
                     k,
@@ -255,7 +255,7 @@ struct champ
                     throw;
                 }
             } else if (node->datamap() & bit) {
-                auto offset = popcount(node->datamap() & (bit - 1));
+                auto offset = popcount(static_cast<bitmap_t>(node->datamap() & (bit - 1)));
                 auto val    = node->values() + offset;
                 if (Equal{}(*val, k))
                     return {
@@ -359,7 +359,7 @@ struct champ
             auto idx = (hash & (mask<B> << shift)) >> shift;
             auto bit = bitmap_t{1u} << idx;
             if (node->nodemap() & bit) {
-                auto offset = popcount(node->nodemap() & (bit - 1));
+                auto offset = popcount(static_cast<bitmap_t>(node->nodemap() & (bit - 1)));
                 auto result =
                     do_sub(node->children()[offset], k, hash, shift + B);
                 switch (result.kind) {
@@ -381,7 +381,7 @@ struct champ
                     }
                 }
             } else if (node->datamap() & bit) {
-                auto offset = popcount(node->datamap() & (bit - 1));
+                auto offset = popcount(static_cast<bitmap_t>(node->datamap() & (bit - 1)));
                 auto val    = node->values() + offset;
                 if (Equal{}(*val, k)) {
                     auto nv = popcount(node->datamap());

--- a/immer/detail/hamts/champ_iterator.hpp
+++ b/immer/detail/hamts/champ_iterator.hpp
@@ -113,7 +113,7 @@ private:
                 if (depth_ < max_depth<B>) {
                     if (child->datamap()) {
                         cur_ = child->values();
-                        end_ = cur_ + child->data__count();
+                        end_ = cur_ + child->data_count();
                     }
                 } else {
                     cur_ = child->collisions();

--- a/immer/detail/hamts/champ_iterator.hpp
+++ b/immer/detail/hamts/champ_iterator.hpp
@@ -35,7 +35,7 @@ struct champ_iterator
     {
         if (v.root->datamap()) {
             cur_ = v.root->values();
-            end_ = v.root->values() + popcount(v.root->datamap());
+            end_ = v.root->values() + v.root->data_count();
         } else {
             cur_ = end_ = nullptr;
         }
@@ -88,7 +88,7 @@ private:
                 if (depth_ < max_depth<B>) {
                     if (child->datamap()) {
                         cur_ = child->values();
-                        end_ = cur_ + popcount(child->datamap());
+                        end_ = cur_ + child->data_count();
                     }
                 } else {
                     cur_ = child->collisions();
@@ -104,7 +104,7 @@ private:
     {
         while (depth_ > 0) {
             auto parent = *path_[depth_ - 1];
-            auto last   = parent->children() + popcount(parent->nodemap());
+            auto last   = parent->children() + parent->children_count();
             auto next   = path_[depth_] + 1;
             if (next < last) {
                 path_[depth_] = next;
@@ -113,7 +113,7 @@ private:
                 if (depth_ < max_depth<B>) {
                     if (child->datamap()) {
                         cur_ = child->values();
-                        end_ = cur_ + popcount(child->datamap());
+                        end_ = cur_ + child->data__count();
                     }
                 } else {
                     cur_ = child->collisions();

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -432,11 +432,11 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         assert(!(src->nodemap() & bit));
         assert(src->datamap() & bit);
-        assert(voffset == popcount(src->datamap() & (bit - 1)));
+        assert(voffset == popcount(static_cast<bitmap_t>(src->datamap() & (bit - 1))));
         auto n                         = popcount(src->nodemap());
         auto nv                        = popcount(src->datamap());
         auto dst                       = make_inner_n(n + 1, nv - 1);
-        auto noffset                   = popcount(src->nodemap() & (bit - 1));
+        auto noffset                   = popcount(static_cast<bitmap_t>(src->nodemap() & (bit - 1)));
         dst->impl.d.data.inner.datamap = src->datamap() & ~bit;
         dst->impl.d.data.inner.nodemap = src->nodemap() | bit;
         if (nv > 1) {
@@ -474,11 +474,11 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         assert(!(src->datamap() & bit));
         assert(src->nodemap() & bit);
-        assert(noffset == popcount(src->nodemap() & (bit - 1)));
+        assert(noffset == popcount(static_cast<bitmap_t>(src->nodemap() & (bit - 1))));
         auto n                         = popcount(src->nodemap());
         auto nv                        = popcount(src->datamap());
         auto dst                       = make_inner_n(n - 1, nv + 1);
-        auto voffset                   = popcount(src->datamap() & (bit - 1));
+        auto voffset                   = popcount(static_cast<bitmap_t>(src->datamap() & (bit - 1)));
         dst->impl.d.data.inner.nodemap = src->nodemap() & ~bit;
         dst->impl.d.data.inner.datamap = src->datamap() | bit;
         try {
@@ -520,7 +520,7 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         assert(!(src->nodemap() & bit));
         assert(src->datamap() & bit);
-        assert(voffset == popcount(src->datamap() & (bit - 1)));
+        assert(voffset == popcount(static_cast<bitmap_t>(src->datamap() & (bit - 1))));
         auto n                         = popcount(src->nodemap());
         auto nv                        = popcount(src->datamap());
         auto dst                       = make_inner_n(n, nv - 1);
@@ -554,7 +554,7 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto n                         = popcount(src->nodemap());
         auto nv                        = popcount(src->datamap());
-        auto offset                    = popcount(src->datamap() & (bit - 1));
+        auto offset                    = popcount(static_cast<bitmap_t>(src->datamap() & (bit - 1)));
         auto dst                       = make_inner_n(n, nv + 1);
         dst->impl.d.data.inner.datamap = src->datamap() | bit;
         dst->impl.d.data.inner.nodemap = src->nodemap();

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -143,6 +143,30 @@ struct node
         return impl.d.data.inner.nodemap;
     }
 
+    auto data_count() const
+    {
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
+        return popcount(datamap());
+    }
+
+    auto data_count(bitmap_t bit) const
+    {
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
+        return popcount(static_cast<bitmap_t>(datamap() & (bit - 1)));
+    }
+
+    auto children_count() const
+    {
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
+        return popcount(nodemap());
+    }
+
+    auto children_count(bitmap_t bit) const
+    {
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
+        return popcount(static_cast<bitmap_t>(nodemap() & (bit - 1)));
+    }
+
     auto collision_count() const
     {
         IMMER_ASSERT_TAGGED(kind() == kind_t::collision);
@@ -383,7 +407,7 @@ struct node
     copy_inner_replace(node_t* src, count_t offset, node_t* child)
     {
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
-        auto n    = popcount(src->nodemap());
+        auto n    = src->children_count();
         auto dst  = make_inner_n(n, src->impl.d.data.inner.values);
         auto srcp = src->children();
         auto dstp = dst->children();
@@ -399,9 +423,9 @@ struct node
     static node_t* copy_inner_replace_value(node_t* src, count_t offset, T v)
     {
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
-        assert(offset < popcount(src->datamap()));
-        auto n                         = popcount(src->nodemap());
-        auto nv                        = popcount(src->datamap());
+        assert(offset < src->data_count());
+        auto n                         = src->children_count();
+        auto nv                        = src->data_count();
         auto dst                       = make_inner_n(n, nv);
         dst->impl.d.data.inner.datamap = src->datamap();
         dst->impl.d.data.inner.nodemap = src->nodemap();
@@ -432,11 +456,11 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         assert(!(src->nodemap() & bit));
         assert(src->datamap() & bit);
-        assert(voffset == popcount(static_cast<bitmap_t>(src->datamap() & (bit - 1))));
-        auto n                         = popcount(src->nodemap());
-        auto nv                        = popcount(src->datamap());
+        assert(voffset == src->data_count(bit));
+        auto n                         = src->children_count();
+        auto nv                        = src->data_count();
         auto dst                       = make_inner_n(n + 1, nv - 1);
-        auto noffset                   = popcount(static_cast<bitmap_t>(src->nodemap() & (bit - 1)));
+        auto noffset                   = src->children_count(bit);
         dst->impl.d.data.inner.datamap = src->datamap() & ~bit;
         dst->impl.d.data.inner.nodemap = src->nodemap() | bit;
         if (nv > 1) {
@@ -474,11 +498,11 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         assert(!(src->datamap() & bit));
         assert(src->nodemap() & bit);
-        assert(noffset == popcount(static_cast<bitmap_t>(src->nodemap() & (bit - 1))));
-        auto n                         = popcount(src->nodemap());
-        auto nv                        = popcount(src->datamap());
+        assert(noffset == src->children_count(bit));
+        auto n                         = src->children_count();
+        auto nv                        = src->data_count();
         auto dst                       = make_inner_n(n - 1, nv + 1);
-        auto voffset                   = popcount(static_cast<bitmap_t>(src->datamap() & (bit - 1)));
+        auto voffset                   = src->data_count(bit);
         dst->impl.d.data.inner.nodemap = src->nodemap() & ~bit;
         dst->impl.d.data.inner.datamap = src->datamap() | bit;
         try {
@@ -520,9 +544,9 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         assert(!(src->nodemap() & bit));
         assert(src->datamap() & bit);
-        assert(voffset == popcount(static_cast<bitmap_t>(src->datamap() & (bit - 1))));
-        auto n                         = popcount(src->nodemap());
-        auto nv                        = popcount(src->datamap());
+        assert(voffset == src->data_count(bit));
+        auto n                         = src->children_count();
+        auto nv                        = src->data_count();
         auto dst                       = make_inner_n(n, nv - 1);
         dst->impl.d.data.inner.datamap = src->datamap() & ~bit;
         dst->impl.d.data.inner.nodemap = src->nodemap();
@@ -552,9 +576,9 @@ struct node
     static node_t* copy_inner_insert_value(node_t* src, bitmap_t bit, T v)
     {
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
-        auto n                         = popcount(src->nodemap());
-        auto nv                        = popcount(src->datamap());
-        auto offset                    = popcount(static_cast<bitmap_t>(src->datamap() & (bit - 1)));
+        auto n                         = src->children_count();
+        auto nv                        = src->data_count();
+        auto offset                    = src->data_count(bit);
         auto dst                       = make_inner_n(n, nv + 1);
         dst->impl.d.data.inner.datamap = src->datamap() | bit;
         dst->impl.d.data.inner.nodemap = src->nodemap();
@@ -591,8 +615,8 @@ struct node
     make_merged(shift_t shift, T v1, hash_t hash1, T v2, hash_t hash2)
     {
         if (shift < max_shift<B>) {
-            auto idx1 = hash1 & (mask<B> << shift);
-            auto idx2 = hash2 & (mask<B> << shift);
+            const count_t idx1 = hash1 & (mask<B> << shift);
+            const count_t idx2 = hash2 & (mask<B> << shift);
             if (idx1 == idx2) {
                 auto merged = make_merged(
                     shift + B, std::move(v1), hash1, std::move(v2), hash2);
@@ -647,8 +671,8 @@ struct node
         IMMER_ASSERT_TAGGED(p->kind() == kind_t::inner);
         auto vp = p->impl.d.data.inner.values;
         if (vp && refs(vp).dec())
-            delete_values(vp, popcount(p->datamap()));
-        deallocate_inner(p, popcount(p->nodemap()));
+            delete_values(vp, p->data_count());
+        deallocate_inner(p, p->children_count());
     }
 
     static void delete_collision(node_t* p)
@@ -665,7 +689,7 @@ struct node
             delete_collision(p);
         else {
             auto fst = p->children();
-            auto lst = fst + popcount(p->nodemap());
+            auto lst = fst + p->children_count();
             for (; fst != lst; ++fst)
                 if ((*fst)->dec())
                     delete_deep(*fst, s + 1);
@@ -679,7 +703,7 @@ struct node
             delete_collision(p);
         else {
             auto fst = p->children();
-            auto lst = fst + popcount(p->nodemap());
+            auto lst = fst + p->children_count();
             for (; fst != lst; ++fst)
                 if ((*fst)->dec())
                     delete_deep_shift(*fst, s + B);


### PR DESCRIPTION
Hi, a small pr from me as was discussed earlier.

I was fighting with integer promotion for some time and the only solution I found so far is to use casts for non-const expressions. Otherwise we get `popcount()` overload ambiguity...

Please take a look and probably you could suggest a better solution for that :)