### PR TITLE
Only use IMMER_SMT_PAUSE when it is defined

### DIFF
--- a/immer/refcount/refcount_policy.hpp
+++ b/immer/refcount/refcount_policy.hpp
@@ -42,8 +42,10 @@ struct spinlock
         for (auto k = 0u; !try_lock(); ++k) {
             if (k < 4)
                 continue;
+#ifdef IMMER_SMT_PAUSE
             else if (k < 16)
                 IMMER_SMT_PAUSE;
+#endif
             else
                 std::this_thread::yield();
         }


### PR DESCRIPTION
IMMER_SMT_PAUSE won't be defined on ARM builds, so we need to fall back to
using std::this_thread::yield().