### PR TITLE
Fix debug_size_heap::extra_size to always be 8 on MinGW 32bit builds

### DIFF
--- a/immer/heap/debug_size_heap.hpp
+++ b/immer/heap/debug_size_heap.hpp
@@ -24,9 +24,18 @@ namespace immer {
 template <typename Base>
 struct debug_size_heap
 {
+#if defined(__MINGW32__) && !defined(__MINGW64__)
+    // There is a bug in MinGW 32bit: https://sourceforge.net/p/mingw-w64/bugs/778/
+    // It causes different versions of std::max_align_t to be defined, depending on inclusion order of stddef.h
+    // and stdint.h. As we have no control over the inclusion order here (as it might be set in stone by the outside
+    // world), we can't easily pin it to one of both versions of std::max_align_t. This means, we have to hardcode
+    // extra_size for MinGW 32bit builds until the mentioned bug is fixed.
+    constexpr static auto extra_size = 8;
+#else
     constexpr static auto extra_size = sizeof(
         std::aligned_storage_t<sizeof(std::size_t),
                                alignof(std::max_align_t)>);
+#endif
 
     template <typename... Tags>
     static void* allocate(std::size_t size, Tags... tags)


### PR DESCRIPTION
As discussed in https://github.com/arximboldi/immer/issues/78

I chose to hardcode it to 8 because the alternative of `sizeof(void*) * 2` is not really connected to how `std::max_align_t` is defined.