### PR TITLE
Add missing include call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments")
 endif()
 
+include(GNUInstallDirs)
 include(ImmerUtils)
 
 #  Options


### PR DESCRIPTION
`CMAKE_INSTALL_INCLUDEDIR` and `CMAKE_INSTALL_LIBDIR` used in `CMakeLists.txt` are defined in `GNUInstallDirs.cmake`. Without including this module, this command will fail:
```bash
$ cmake --build . --target install
```
>  -- Install configuration: "Debug"
  -- Up-to-date: /cmake/Immer/ImmerConfig.cmake
  CMake Error at cmake_install.cmake:60 (file):
    file INSTALL given no DESTINATION