### PR TITLE
Fix warnings with msvc + [[nodiscard]] support

### DIFF
--- a/immer/config.hpp
+++ b/immer/config.hpp
@@ -8,14 +8,17 @@
 
 #pragma once
 
-#if defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard)
-#define IMMER_NODISCARD [[nodiscard]]
-#elif defined(__has_cpp_attribute) && __has_cpp_attribute(gnu::warn_unused_result)
-// This seems to be causing problems in GCC 6, where when used, methods
-// overloads based on the value category (&, &&) are detected as ambiguous
-//   #define IMMER_NODISCARD [[gnu::warn_unused_result]]
-#define IMMER_NODISCARD
-#else
+#if defined(__has_cpp_attribute)
+ #if __has_cpp_attribute(nodiscard)
+  #define IMMER_NODISCARD [[nodiscard]]
+ #endif
+#endif
+
+#if _MSVC_LANG >= 201703L
+ #define IMMER_NODISCARD [[nodiscard]]
+#endif
+
+#ifndef IMMER_NODISCARD
 #define IMMER_NODISCARD
 #endif
 

--- a/immer/config.hpp
+++ b/immer/config.hpp
@@ -18,6 +18,10 @@
  #endif
 #endif
 
+#ifndef IMMER_NODISCARD
+#define IMMER_NODISCARD
+#endif
+
 #ifndef IMMER_DEBUG_TRACES
 #define IMMER_DEBUG_TRACES 0
 #endif

--- a/immer/config.hpp
+++ b/immer/config.hpp
@@ -12,14 +12,10 @@
  #if __has_cpp_attribute(nodiscard)
   #define IMMER_NODISCARD [[nodiscard]]
  #endif
-#endif
-
-#if _MSVC_LANG >= 201703L
- #define IMMER_NODISCARD [[nodiscard]]
-#endif
-
-#ifndef IMMER_NODISCARD
-#define IMMER_NODISCARD
+#else
+ #if _MSVC_LANG >= 201703L
+  #define IMMER_NODISCARD [[nodiscard]]
+ #endif
 #endif
 
 #ifndef IMMER_DEBUG_TRACES


### PR DESCRIPTION
The macro to check for "[[nodiscard]]" compiler support did not work with MSVC 19.16 and produced warnings:
https://godbolt.org/z/2-EjTj
"warning C4067: unexpected tokens following preprocessor directive - expected a newline"

This patch removes the warning and enables the attribute, if the Microsoft compiler is running in C++17 mode.