### PR TITLE
Fix issues with unaligned data types on immer::set

### DIFF
--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -92,8 +92,9 @@ struct node
 
     constexpr static std::size_t sizeof_values_n(count_t count)
     {
-        return immer_offsetof(values_t, d.buffer)
-            + sizeof(values_data_t::buffer) * count;
+        return std::max(sizeof(values_t),
+                        immer_offsetof(values_t, d.buffer)
+                        + sizeof(values_data_t::buffer) * count);
     }
 
     constexpr static std::size_t sizeof_collision_n(count_t count)

--- a/shell.nix
+++ b/shell.nix
@@ -57,4 +57,5 @@ theStdenv.mkDerivation rec {
     export CC=${compilerPkg}/bin/cc
     export CXX=${compilerPkg}/bin/c++
   '';
+  hardeningDisable = [ "fortify" ];
 }


### PR DESCRIPTION
RFC @mrpi!

This fixes issue #88. It just makes the test you gave me pass, but I have not checked with other data-structures. Did you face similar problems with other containers indeed?
