### PR TITLE
Do not set value of IMMER_{HAMTS,RBTS}_TAGGED_NODE if it is already set

### DIFF
--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -14,10 +14,12 @@
 
 #include <cassert>
 
+#ifndef IMMER_HAMTS_TAGGED_NODE
 #ifdef NDEBUG
 #define IMMER_HAMTS_TAGGED_NODE 0
 #else
 #define IMMER_HAMTS_TAGGED_NODE 1
+#endif
 #endif
 
 namespace immer {

--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -18,10 +18,12 @@
 #include <memory>
 #include <type_traits>
 
+#ifndef IMMER_RBTS_TAGGED_NODE
 #ifdef NDEBUG
 #define IMMER_RBTS_TAGGED_NODE 0
 #else
 #define IMMER_RBTS_TAGGED_NODE 1
+#endif
 #endif
 
 namespace immer {


### PR DESCRIPTION
Currently the data layout of the immer data types depends on the value
of the NDEBUG macro. This is rather unfortunate because if a library is
built with debugging disabled, and then linked into an application built
with debugging enabled, the code will crash with an assertion error.

Thus, I provide a way to explicitly set the layout intended for the
application so that it does not get overridden by the value of NDEBUG,
which allows the user to have a consistent data layout across multiple
code units with different values of debugging.