### PR TITLE
Make tagged nodes configurable

### DIFF
--- a/immer/config.hpp
+++ b/immer/config.hpp
@@ -22,6 +22,20 @@
 #define IMMER_NODISCARD
 #endif
 
+#ifndef IMMER_TAGGED_NODE
+ #ifdef NDEBUG
+  #define IMMER_TAGGED_NODE 0
+ #else
+  #define IMMER_TAGGED_NODE 1
+ #endif
+#endif
+
+#if IMMER_TAGGED_NODE
+ #define assertKind(assertion) assert(assertion)
+#else
+ #define assertKind(assertion)
+#endif
+
 #ifndef IMMER_DEBUG_TRACES
 #define IMMER_DEBUG_TRACES 0
 #endif

--- a/immer/config.hpp
+++ b/immer/config.hpp
@@ -31,9 +31,9 @@
 #endif
 
 #if IMMER_TAGGED_NODE
- #define assertKind(assertion) assert(assertion)
+ #define IMMER_ASSERT_TAGGED(assertion) assert(assertion)
 #else
- #define assertKind(assertion)
+ #define IMMER_ASSERT_TAGGED(assertion)
 #endif
 
 #ifndef IMMER_DEBUG_TRACES

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -14,12 +14,6 @@
 
 #include <cassert>
 
-#ifdef NDEBUG
-#define IMMER_TAGGED_NODE 0
-#else
-#define IMMER_TAGGED_NODE 1
-#endif
-
 namespace immer {
 namespace detail {
 namespace hamts {

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -112,57 +112,57 @@ struct node
 
     auto values()
     {
-        assertKind(kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
         assert(impl.d.data.inner.values);
         return (T*) &impl.d.data.inner.values->d.buffer;
     }
 
     auto values() const
     {
-        assertKind(kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
         assert(impl.d.data.inner.values);
         return (const T*) &impl.d.data.inner.values->d.buffer;
     }
 
     auto children()
     {
-        assertKind(kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
         return (node_t**) &impl.d.data.inner.buffer;
     }
 
     auto children() const
     {
-        assertKind(kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
         return (const node_t* const*) &impl.d.data.inner.buffer;
     }
 
     auto datamap() const
     {
-        assertKind(kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
         return impl.d.data.inner.datamap;
     }
 
     auto nodemap() const
     {
-        assertKind(kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
         return impl.d.data.inner.nodemap;
     }
 
     auto collision_count() const
     {
-        assertKind(kind() == kind_t::collision);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::collision);
         return impl.d.data.collision.count;
     }
 
     T* collisions()
     {
-        assertKind(kind() == kind_t::collision);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::collision);
         return (T*)&impl.d.data.collision.buffer;
     }
 
     const T* collisions() const
     {
-        assertKind(kind() == kind_t::collision);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::collision);
         return (const T*)&impl.d.data.collision.buffer;
     }
 
@@ -305,7 +305,7 @@ struct node
 
     static node_t* copy_collision_insert(node_t* src, T v)
     {
-        assertKind(src->kind() == kind_t::collision);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::collision);
         auto n    = src->collision_count();
         auto dst  = make_collision_n(n + 1);
         auto srcp = src->collisions();
@@ -327,7 +327,7 @@ struct node
 
     static node_t* copy_collision_remove(node_t* src, T* v)
     {
-        assertKind(src->kind() == kind_t::collision);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::collision);
         assert(src->collision_count() > 1);
         auto n    = src->collision_count();
         auto dst  = make_collision_n(n - 1);
@@ -350,7 +350,7 @@ struct node
 
     static node_t* copy_collision_replace(node_t* src, T* pos, T v)
     {
-        assertKind(src->kind() == kind_t::collision);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::collision);
         auto n    = src->collision_count();
         auto dst  = make_collision_n(n);
         auto srcp = src->collisions();
@@ -380,7 +380,7 @@ struct node
     static node_t* copy_inner_replace(node_t* src,
                                       count_t offset, node_t* child)
     {
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto n    = popcount(src->nodemap());
         auto dst  = make_inner_n(n, src->impl.d.data.inner.values);
         auto srcp = src->children();
@@ -397,7 +397,7 @@ struct node
     static node_t* copy_inner_replace_value(node_t* src,
                                             count_t offset, T v)
     {
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         assert(offset < popcount(src->datamap()));
         auto n    = popcount(src->nodemap());
         auto nv   = popcount(src->datamap());
@@ -426,7 +426,7 @@ struct node
     static node_t* copy_inner_replace_merged(
         node_t* src, bitmap_t bit, count_t voffset, node_t* node)
     {
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         assert(!(src->nodemap() & bit));
         assert(src->datamap() & bit);
         assert(voffset == popcount(src->datamap() & (bit - 1)));
@@ -468,7 +468,7 @@ struct node
     static node_t* copy_inner_replace_inline(
         node_t* src, bitmap_t bit, count_t noffset, T value)
     {
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         assert(!(src->datamap() & bit));
         assert(src->nodemap() & bit);
         assert(noffset == popcount(src->nodemap() & (bit - 1)));
@@ -516,7 +516,7 @@ struct node
     static node_t* copy_inner_remove_value(
         node_t* src, bitmap_t bit, count_t voffset)
     {
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         assert(!(src->nodemap() & bit));
         assert(src->datamap() & bit);
         assert(voffset == popcount(src->datamap() & (bit - 1)));
@@ -551,7 +551,7 @@ struct node
 
     static node_t* copy_inner_insert_value(node_t* src, bitmap_t bit, T v)
     {
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto n      = popcount(src->nodemap());
         auto nv     = popcount(src->datamap());
         auto offset = popcount(src->datamap() & (bit - 1));
@@ -644,7 +644,7 @@ struct node
     static void delete_inner(node_t* p)
     {
         assert(p);
-        assertKind(p->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(p->kind() == kind_t::inner);
         auto vp = p->impl.d.data.inner.values;
         if (vp && refs(vp).dec())
             delete_values(vp, popcount(p->datamap()));
@@ -654,7 +654,7 @@ struct node
     static void delete_collision(node_t* p)
     {
         assert(p);
-        assertKind(p->kind() == kind_t::collision);
+        IMMER_ASSERT_TAGGED(p->kind() == kind_t::collision);
         auto n = p->collision_count();
         deallocate_collision(p, n);
     }

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -15,9 +15,9 @@
 #include <cassert>
 
 #ifdef NDEBUG
-#define IMMER_HAMTS_TAGGED_NODE 0
+#define IMMER_TAGGED_NODE 0
 #else
-#define IMMER_HAMTS_TAGGED_NODE 1
+#define IMMER_TAGGED_NODE 1
 #endif
 
 namespace immer {
@@ -79,7 +79,7 @@ struct node
 
     struct impl_data_t
     {
-#if IMMER_HAMTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
         kind_t kind;
 #endif
         data_t data;
@@ -109,7 +109,7 @@ struct node
             + sizeof(inner_t::buffer) * count;
     }
 
-#if IMMER_HAMTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
     kind_t kind() const
     {
         return impl.d.kind;
@@ -118,57 +118,57 @@ struct node
 
     auto values()
     {
-        assert(kind() == kind_t::inner);
+        assertKind(kind() == kind_t::inner);
         assert(impl.d.data.inner.values);
         return (T*) &impl.d.data.inner.values->d.buffer;
     }
 
     auto values() const
     {
-        assert(kind() == kind_t::inner);
+        assertKind(kind() == kind_t::inner);
         assert(impl.d.data.inner.values);
         return (const T*) &impl.d.data.inner.values->d.buffer;
     }
 
     auto children()
     {
-        assert(kind() == kind_t::inner);
+        assertKind(kind() == kind_t::inner);
         return (node_t**) &impl.d.data.inner.buffer;
     }
 
     auto children() const
     {
-        assert(kind() == kind_t::inner);
+        assertKind(kind() == kind_t::inner);
         return (const node_t* const*) &impl.d.data.inner.buffer;
     }
 
     auto datamap() const
     {
-        assert(kind() == kind_t::inner);
+        assertKind(kind() == kind_t::inner);
         return impl.d.data.inner.datamap;
     }
 
     auto nodemap() const
     {
-        assert(kind() == kind_t::inner);
+        assertKind(kind() == kind_t::inner);
         return impl.d.data.inner.nodemap;
     }
 
     auto collision_count() const
     {
-        assert(kind() == kind_t::collision);
+        assertKind(kind() == kind_t::collision);
         return impl.d.data.collision.count;
     }
 
     T* collisions()
     {
-        assert(kind() == kind_t::collision);
+        assertKind(kind() == kind_t::collision);
         return (T*)&impl.d.data.collision.buffer;
     }
 
     const T* collisions() const
     {
-        assert(kind() == kind_t::collision);
+        assertKind(kind() == kind_t::collision);
         return (const T*)&impl.d.data.collision.buffer;
     }
 
@@ -185,7 +185,7 @@ struct node
         assert(n <= branches<B>);
         auto m = heap::allocate(sizeof_inner_n(n));
         auto p = new (m) node_t;
-#if IMMER_HAMTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
         p->impl.d.kind = node_t::kind_t::inner;
 #endif
         p->impl.d.data.inner.nodemap = 0;
@@ -278,7 +278,7 @@ struct node
         assert(n <= branches<B>);
         auto m = heap::allocate(sizeof_collision_n(n));
         auto p = new (m) node_t;
-#if IMMER_HAMTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
         p->impl.d.kind = node_t::kind_t::collision;
 #endif
         p->impl.d.data.collision.count = n;
@@ -289,7 +289,7 @@ struct node
     {
         auto m = heap::allocate(sizeof_collision_n(2));
         auto p = new (m) node_t;
-#if IMMER_HAMTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
         p->impl.d.kind = node_t::kind_t::collision;
 #endif
         p->impl.d.data.collision.count = 2;
@@ -311,7 +311,7 @@ struct node
 
     static node_t* copy_collision_insert(node_t* src, T v)
     {
-        assert(src->kind() == kind_t::collision);
+        assertKind(src->kind() == kind_t::collision);
         auto n    = src->collision_count();
         auto dst  = make_collision_n(n + 1);
         auto srcp = src->collisions();
@@ -333,7 +333,7 @@ struct node
 
     static node_t* copy_collision_remove(node_t* src, T* v)
     {
-        assert(src->kind() == kind_t::collision);
+        assertKind(src->kind() == kind_t::collision);
         assert(src->collision_count() > 1);
         auto n    = src->collision_count();
         auto dst  = make_collision_n(n - 1);
@@ -356,7 +356,7 @@ struct node
 
     static node_t* copy_collision_replace(node_t* src, T* pos, T v)
     {
-        assert(src->kind() == kind_t::collision);
+        assertKind(src->kind() == kind_t::collision);
         auto n    = src->collision_count();
         auto dst  = make_collision_n(n);
         auto srcp = src->collisions();
@@ -386,7 +386,7 @@ struct node
     static node_t* copy_inner_replace(node_t* src,
                                       count_t offset, node_t* child)
     {
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         auto n    = popcount(src->nodemap());
         auto dst  = make_inner_n(n, src->impl.d.data.inner.values);
         auto srcp = src->children();
@@ -403,7 +403,7 @@ struct node
     static node_t* copy_inner_replace_value(node_t* src,
                                             count_t offset, T v)
     {
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         assert(offset < popcount(src->datamap()));
         auto n    = popcount(src->nodemap());
         auto nv   = popcount(src->datamap());
@@ -432,7 +432,7 @@ struct node
     static node_t* copy_inner_replace_merged(
         node_t* src, bitmap_t bit, count_t voffset, node_t* node)
     {
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         assert(!(src->nodemap() & bit));
         assert(src->datamap() & bit);
         assert(voffset == popcount(src->datamap() & (bit - 1)));
@@ -474,7 +474,7 @@ struct node
     static node_t* copy_inner_replace_inline(
         node_t* src, bitmap_t bit, count_t noffset, T value)
     {
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         assert(!(src->datamap() & bit));
         assert(src->nodemap() & bit);
         assert(noffset == popcount(src->nodemap() & (bit - 1)));
@@ -522,7 +522,7 @@ struct node
     static node_t* copy_inner_remove_value(
         node_t* src, bitmap_t bit, count_t voffset)
     {
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         assert(!(src->nodemap() & bit));
         assert(src->datamap() & bit);
         assert(voffset == popcount(src->datamap() & (bit - 1)));
@@ -557,7 +557,7 @@ struct node
 
     static node_t* copy_inner_insert_value(node_t* src, bitmap_t bit, T v)
     {
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         auto n      = popcount(src->nodemap());
         auto nv     = popcount(src->datamap());
         auto offset = popcount(src->datamap() & (bit - 1));
@@ -650,7 +650,7 @@ struct node
     static void delete_inner(node_t* p)
     {
         assert(p);
-        assert(p->kind() == kind_t::inner);
+        assertKind(p->kind() == kind_t::inner);
         auto vp = p->impl.d.data.inner.values;
         if (vp && refs(vp).dec())
             delete_values(vp, popcount(p->datamap()));
@@ -660,7 +660,7 @@ struct node
     static void delete_collision(node_t* p)
     {
         assert(p);
-        assert(p->kind() == kind_t::collision);
+        assertKind(p->kind() == kind_t::collision);
         auto n = p->collision_count();
         deallocate_collision(p, n);
     }

--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -19,9 +19,9 @@
 #include <type_traits>
 
 #ifdef NDEBUG
-#define IMMER_RBTS_TAGGED_NODE 0
+#define IMMER_TAGGED_NODE 0
 #else
-#define IMMER_RBTS_TAGGED_NODE 1
+#define IMMER_TAGGED_NODE 1
 #endif
 
 namespace immer {
@@ -91,7 +91,7 @@ struct node
 
     struct impl_data_t
     {
-#if IMMER_RBTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
         kind_t kind;
 #endif
         data_t data;
@@ -159,7 +159,7 @@ struct node
     using heap = typename heap_policy::template
         optimized<max_sizeof_inner>::type;
 
-#if IMMER_RBTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
     kind_t kind() const
     {
         return impl.d.kind;
@@ -168,25 +168,25 @@ struct node
 
     relaxed_t* relaxed()
     {
-        assert(kind() == kind_t::inner);
+        assertKind(kind() == kind_t::inner);
         return impl.d.data.inner.relaxed;
     }
 
     const relaxed_t* relaxed() const
     {
-        assert(kind() == kind_t::inner);
+        assertKind(kind() == kind_t::inner);
         return impl.d.data.inner.relaxed;
     }
 
     node_t** inner()
     {
-        assert(kind() == kind_t::inner);
+        assertKind(kind() == kind_t::inner);
         return reinterpret_cast<node_t**>(&impl.d.data.inner.buffer);
     }
 
     T* leaf()
     {
-        assert(kind() == kind_t::leaf);
+        assertKind(kind() == kind_t::leaf);
         return reinterpret_cast<T*>(&impl.d.data.leaf.buffer);
     }
 
@@ -204,7 +204,7 @@ struct node
         auto m = heap::allocate(sizeof_inner_n(n));
         auto p = new (m) node_t;
         p->impl.d.data.inner.relaxed = nullptr;
-#if IMMER_RBTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
         p->impl.d.kind = node_t::kind_t::inner;
 #endif
         return p;
@@ -216,7 +216,7 @@ struct node
         auto p = new (m) node_t;
         ownee(p) = e;
         p->impl.d.data.inner.relaxed = nullptr;
-#if IMMER_RBTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
         p->impl.d.kind = node_t::kind_t::inner;
 #endif
         return p;
@@ -241,7 +241,7 @@ struct node
         auto r = new (mr) relaxed_t;
         r->d.count = 0;
         p->impl.d.data.inner.relaxed = r;
-#if IMMER_RBTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
         p->impl.d.kind = node_t::kind_t::inner;
 #endif
         return p;
@@ -258,7 +258,7 @@ struct node
                 assert(r->d.count >= n);
                 node_t::refs(r).inc();
                 p->impl.d.data.inner.relaxed = r;
-#if IMMER_RBTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
                 p->impl.d.kind = node_t::kind_t::inner;
 #endif
                 return p;
@@ -285,7 +285,7 @@ struct node
         static_if<!embed_relaxed>([&](auto){ node_t::ownee(r) = e; });
         r->d.count = 0;
         p->impl.d.data.inner.relaxed = r;
-#if IMMER_RBTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
         p->impl.d.kind = node_t::kind_t::inner;
 #endif
         return p;
@@ -302,7 +302,7 @@ struct node
                 node_t::refs(r).inc();
                 p->impl.d.data.inner.relaxed = r;
                 node_t::ownee(p) = e;
-#if IMMER_RBTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
                 p->impl.d.kind = node_t::kind_t::inner;
 #endif
                 return p;
@@ -313,7 +313,7 @@ struct node
     {
         assert(n <= branches<BL>);
         auto p = new (heap::allocate(sizeof_leaf_n(n))) node_t;
-#if IMMER_RBTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
         p->impl.d.kind = node_t::kind_t::leaf;
 #endif
         return p;
@@ -323,7 +323,7 @@ struct node
     {
         auto p = new (heap::allocate(max_sizeof_leaf)) node_t;
         ownee(p) = e;
-#if IMMER_RBTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
         p->impl.d.kind = node_t::kind_t::leaf;
 #endif
         return p;
@@ -462,7 +462,7 @@ struct node
 
     static node_t* make_path(shift_t shift, node_t* node)
     {
-        assert(node->kind() == kind_t::leaf);
+        assertKind(node->kind() == kind_t::leaf);
         if (shift == endshift<B, BL>)
             return node;
         else {
@@ -479,7 +479,7 @@ struct node
 
     static node_t* make_path_e(edit_t e, shift_t shift, node_t* node)
     {
-        assert(node->kind() == kind_t::leaf);
+        assertKind(node->kind() == kind_t::leaf);
         if (shift == endshift<B, BL>)
             return node;
         else {
@@ -496,7 +496,7 @@ struct node
 
     static node_t* copy_inner(node_t* src, count_t n)
     {
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         auto dst = make_inner_n(n);
         inc_nodes(src->inner(), n);
         std::uninitialized_copy(src->inner(), src->inner() + n, dst->inner());
@@ -506,22 +506,22 @@ struct node
     static node_t* copy_inner_n(count_t allocn, node_t* src, count_t n)
     {
         assert(allocn >= n);
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         auto dst = make_inner_n(allocn);
         return do_copy_inner(dst, src, n);
     }
 
     static node_t* copy_inner_e(edit_t e, node_t* src, count_t n)
     {
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         auto dst = make_inner_e(e);
         return do_copy_inner(dst, src, n);
     }
 
     static node_t* do_copy_inner(node_t* dst, node_t* src, count_t n)
     {
-        assert(dst->kind() == kind_t::inner);
-        assert(src->kind() == kind_t::inner);
+        assertKind(dst->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         auto p = src->inner();
         inc_nodes(p, n);
         std::uninitialized_copy(p, p + n, dst->inner());
@@ -530,7 +530,7 @@ struct node
 
     static node_t* copy_inner_r(node_t* src, count_t n)
     {
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         auto dst = make_inner_r_n(n);
         return do_copy_inner_r(dst, src, n);
     }
@@ -538,29 +538,29 @@ struct node
     static node_t* copy_inner_r_n(count_t allocn, node_t* src, count_t n)
     {
         assert(allocn >= n);
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         auto dst = make_inner_r_n(allocn);
         return do_copy_inner_r(dst, src, n);
     }
 
     static node_t* copy_inner_r_e(edit_t e, node_t* src, count_t n)
     {
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         auto dst = make_inner_r_e(e);
         return do_copy_inner_r(dst, src, n);
     }
 
     static node_t* copy_inner_sr_e(edit_t e, node_t* src, count_t n)
     {
-        assert(src->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         auto dst = make_inner_sr_e(e, src->relaxed());
         return do_copy_inner_sr(dst, src, n);
     }
 
     static node_t* do_copy_inner_r(node_t* dst, node_t* src, count_t n)
     {
-        assert(dst->kind() == kind_t::inner);
-        assert(src->kind() == kind_t::inner);
+        assertKind(dst->kind() == kind_t::inner);
+        assertKind(src->kind() == kind_t::inner);
         auto src_r = src->relaxed();
         auto dst_r = dst->relaxed();
         inc_nodes(src->inner(), n);
@@ -583,7 +583,7 @@ struct node
 
     static node_t* copy_leaf(node_t* src, count_t n)
     {
-        assert(src->kind() == kind_t::leaf);
+        assertKind(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(n);
         try {
             std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
@@ -596,7 +596,7 @@ struct node
 
     static node_t* copy_leaf_e(edit_t e, node_t* src, count_t n)
     {
-        assert(src->kind() == kind_t::leaf);
+        assertKind(src->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
         try {
             std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
@@ -610,7 +610,7 @@ struct node
     static node_t* copy_leaf_n(count_t allocn, node_t* src, count_t n)
     {
         assert(allocn >= n);
-        assert(src->kind() == kind_t::leaf);
+        assertKind(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(allocn);
         try {
             std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
@@ -624,8 +624,8 @@ struct node
     static node_t* copy_leaf(node_t* src1, count_t n1,
                              node_t* src2, count_t n2)
     {
-        assert(src1->kind() == kind_t::leaf);
-        assert(src2->kind() == kind_t::leaf);
+        assertKind(src1->kind() == kind_t::leaf);
+        assertKind(src2->kind() == kind_t::leaf);
         auto dst = make_leaf_n(n1 + n2);
         try {
             std::uninitialized_copy(
@@ -649,8 +649,8 @@ struct node
                                node_t* src1, count_t n1,
                                node_t* src2, count_t n2)
     {
-        assert(src1->kind() == kind_t::leaf);
-        assert(src2->kind() == kind_t::leaf);
+        assertKind(src1->kind() == kind_t::leaf);
+        assertKind(src2->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
         try {
             std::uninitialized_copy(
@@ -672,7 +672,7 @@ struct node
 
     static node_t* copy_leaf_e(edit_t e, node_t* src, count_t idx, count_t last)
     {
-        assert(src->kind() == kind_t::leaf);
+        assertKind(src->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
         try {
             std::uninitialized_copy(
@@ -686,7 +686,7 @@ struct node
 
     static node_t* copy_leaf(node_t* src, count_t idx, count_t last)
     {
-        assert(src->kind() == kind_t::leaf);
+        assertKind(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(last - idx);
         try {
             std::uninitialized_copy(
@@ -714,7 +714,7 @@ struct node
 
     static void delete_inner(node_t* p, count_t n)
     {
-        assert(p->kind() == kind_t::inner);
+        assertKind(p->kind() == kind_t::inner);
         assert(!p->relaxed());
         heap::deallocate(ownee(p).owned()
                          ? node_t::max_sizeof_inner
@@ -723,7 +723,7 @@ struct node
 
     static void delete_inner_e(node_t* p)
     {
-        assert(p->kind() == kind_t::inner);
+        assertKind(p->kind() == kind_t::inner);
         assert(!p->relaxed());
         heap::deallocate(node_t::max_sizeof_inner, p);
     }
@@ -738,7 +738,7 @@ struct node
 
     static void delete_inner_r(node_t* p, count_t n)
     {
-        assert(p->kind() == kind_t::inner);
+        assertKind(p->kind() == kind_t::inner);
         auto r = p->relaxed();
         assert(r);
         static_if<!embed_relaxed>([&] (auto) {
@@ -754,7 +754,7 @@ struct node
 
     static void delete_inner_r_e(node_t* p)
     {
-        assert(p->kind() == kind_t::inner);
+        assertKind(p->kind() == kind_t::inner);
         auto r = p->relaxed();
         assert(r);
         static_if<!embed_relaxed>([&] (auto) {
@@ -766,7 +766,7 @@ struct node
 
     static void delete_leaf(node_t* p, count_t n)
     {
-        assert(p->kind() == kind_t::leaf);
+        assertKind(p->kind() == kind_t::leaf);
         destroy_n(p->leaf(), n);
         heap::deallocate(ownee(p).owned()
                          ? node_t::max_sizeof_leaf
@@ -867,7 +867,7 @@ struct node
             refs(*i).inc();
     }
 
-#if IMMER_RBTS_TAGGED_NODE
+#if IMMER_TAGGED_NODE
     shift_t compute_shift()
     {
         if (kind() == kind_t::leaf)
@@ -882,7 +882,7 @@ struct node
 #if IMMER_DEBUG_DEEP_CHECK
         assert(size > 0);
         if (shift == endshift<B, BL>) {
-            assert(kind() == kind_t::leaf);
+            assertKind(kind() == kind_t::leaf);
             assert(size <= branches<BL>);
         } else if (auto r = relaxed()) {
             auto count = r->d.count;

--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -162,25 +162,25 @@ struct node
 
     relaxed_t* relaxed()
     {
-        assertKind(kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
         return impl.d.data.inner.relaxed;
     }
 
     const relaxed_t* relaxed() const
     {
-        assertKind(kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
         return impl.d.data.inner.relaxed;
     }
 
     node_t** inner()
     {
-        assertKind(kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::inner);
         return reinterpret_cast<node_t**>(&impl.d.data.inner.buffer);
     }
 
     T* leaf()
     {
-        assertKind(kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(kind() == kind_t::leaf);
         return reinterpret_cast<T*>(&impl.d.data.leaf.buffer);
     }
 
@@ -456,7 +456,7 @@ struct node
 
     static node_t* make_path(shift_t shift, node_t* node)
     {
-        assertKind(node->kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(node->kind() == kind_t::leaf);
         if (shift == endshift<B, BL>)
             return node;
         else {
@@ -473,7 +473,7 @@ struct node
 
     static node_t* make_path_e(edit_t e, shift_t shift, node_t* node)
     {
-        assertKind(node->kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(node->kind() == kind_t::leaf);
         if (shift == endshift<B, BL>)
             return node;
         else {
@@ -490,7 +490,7 @@ struct node
 
     static node_t* copy_inner(node_t* src, count_t n)
     {
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto dst = make_inner_n(n);
         inc_nodes(src->inner(), n);
         std::uninitialized_copy(src->inner(), src->inner() + n, dst->inner());
@@ -500,22 +500,22 @@ struct node
     static node_t* copy_inner_n(count_t allocn, node_t* src, count_t n)
     {
         assert(allocn >= n);
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto dst = make_inner_n(allocn);
         return do_copy_inner(dst, src, n);
     }
 
     static node_t* copy_inner_e(edit_t e, node_t* src, count_t n)
     {
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto dst = make_inner_e(e);
         return do_copy_inner(dst, src, n);
     }
 
     static node_t* do_copy_inner(node_t* dst, node_t* src, count_t n)
     {
-        assertKind(dst->kind() == kind_t::inner);
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(dst->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto p = src->inner();
         inc_nodes(p, n);
         std::uninitialized_copy(p, p + n, dst->inner());
@@ -524,7 +524,7 @@ struct node
 
     static node_t* copy_inner_r(node_t* src, count_t n)
     {
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto dst = make_inner_r_n(n);
         return do_copy_inner_r(dst, src, n);
     }
@@ -532,29 +532,29 @@ struct node
     static node_t* copy_inner_r_n(count_t allocn, node_t* src, count_t n)
     {
         assert(allocn >= n);
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto dst = make_inner_r_n(allocn);
         return do_copy_inner_r(dst, src, n);
     }
 
     static node_t* copy_inner_r_e(edit_t e, node_t* src, count_t n)
     {
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto dst = make_inner_r_e(e);
         return do_copy_inner_r(dst, src, n);
     }
 
     static node_t* copy_inner_sr_e(edit_t e, node_t* src, count_t n)
     {
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto dst = make_inner_sr_e(e, src->relaxed());
         return do_copy_inner_sr(dst, src, n);
     }
 
     static node_t* do_copy_inner_r(node_t* dst, node_t* src, count_t n)
     {
-        assertKind(dst->kind() == kind_t::inner);
-        assertKind(src->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(dst->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto src_r = src->relaxed();
         auto dst_r = dst->relaxed();
         inc_nodes(src->inner(), n);
@@ -577,7 +577,7 @@ struct node
 
     static node_t* copy_leaf(node_t* src, count_t n)
     {
-        assertKind(src->kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(n);
         try {
             std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
@@ -590,7 +590,7 @@ struct node
 
     static node_t* copy_leaf_e(edit_t e, node_t* src, count_t n)
     {
-        assertKind(src->kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
         try {
             std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
@@ -604,7 +604,7 @@ struct node
     static node_t* copy_leaf_n(count_t allocn, node_t* src, count_t n)
     {
         assert(allocn >= n);
-        assertKind(src->kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(allocn);
         try {
             std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
@@ -618,8 +618,8 @@ struct node
     static node_t* copy_leaf(node_t* src1, count_t n1,
                              node_t* src2, count_t n2)
     {
-        assertKind(src1->kind() == kind_t::leaf);
-        assertKind(src2->kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(src1->kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(src2->kind() == kind_t::leaf);
         auto dst = make_leaf_n(n1 + n2);
         try {
             std::uninitialized_copy(
@@ -643,8 +643,8 @@ struct node
                                node_t* src1, count_t n1,
                                node_t* src2, count_t n2)
     {
-        assertKind(src1->kind() == kind_t::leaf);
-        assertKind(src2->kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(src1->kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(src2->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
         try {
             std::uninitialized_copy(
@@ -666,7 +666,7 @@ struct node
 
     static node_t* copy_leaf_e(edit_t e, node_t* src, count_t idx, count_t last)
     {
-        assertKind(src->kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
         try {
             std::uninitialized_copy(
@@ -680,7 +680,7 @@ struct node
 
     static node_t* copy_leaf(node_t* src, count_t idx, count_t last)
     {
-        assertKind(src->kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(last - idx);
         try {
             std::uninitialized_copy(
@@ -708,7 +708,7 @@ struct node
 
     static void delete_inner(node_t* p, count_t n)
     {
-        assertKind(p->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(p->kind() == kind_t::inner);
         assert(!p->relaxed());
         heap::deallocate(ownee(p).owned()
                          ? node_t::max_sizeof_inner
@@ -717,7 +717,7 @@ struct node
 
     static void delete_inner_e(node_t* p)
     {
-        assertKind(p->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(p->kind() == kind_t::inner);
         assert(!p->relaxed());
         heap::deallocate(node_t::max_sizeof_inner, p);
     }
@@ -732,7 +732,7 @@ struct node
 
     static void delete_inner_r(node_t* p, count_t n)
     {
-        assertKind(p->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(p->kind() == kind_t::inner);
         auto r = p->relaxed();
         assert(r);
         static_if<!embed_relaxed>([&] (auto) {
@@ -748,7 +748,7 @@ struct node
 
     static void delete_inner_r_e(node_t* p)
     {
-        assertKind(p->kind() == kind_t::inner);
+        IMMER_ASSERT_TAGGED(p->kind() == kind_t::inner);
         auto r = p->relaxed();
         assert(r);
         static_if<!embed_relaxed>([&] (auto) {
@@ -760,7 +760,7 @@ struct node
 
     static void delete_leaf(node_t* p, count_t n)
     {
-        assertKind(p->kind() == kind_t::leaf);
+        IMMER_ASSERT_TAGGED(p->kind() == kind_t::leaf);
         destroy_n(p->leaf(), n);
         heap::deallocate(ownee(p).owned()
                          ? node_t::max_sizeof_leaf
@@ -876,7 +876,7 @@ struct node
 #if IMMER_DEBUG_DEEP_CHECK
         assert(size > 0);
         if (shift == endshift<B, BL>) {
-            assertKind(kind() == kind_t::leaf);
+            IMMER_ASSERT_TAGGED(kind() == kind_t::leaf);
             assert(size <= branches<BL>);
         } else if (auto r = relaxed()) {
             auto count = r->d.count;

--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -18,12 +18,6 @@
 #include <memory>
 #include <type_traits>
 
-#ifdef NDEBUG
-#define IMMER_TAGGED_NODE 0
-#else
-#define IMMER_TAGGED_NODE 1
-#endif
-
 namespace immer {
 namespace detail {
 namespace rbts {

--- a/immer/detail/rbts/position.hpp
+++ b/immer/detail/rbts/position.hpp
@@ -711,7 +711,7 @@ template <typename NodeT>
 auto make_singleton_regular_sub_pos(NodeT* leaf, count_t count)
 {
     assert(leaf);
-    assertKind(leaf->kind() == NodeT::kind_t::leaf);
+    IMMER_ASSERT_TAGGED(leaf->kind() == NodeT::kind_t::leaf);
     assert(count > 0);
     return singleton_regular_sub_pos<NodeT>{leaf, count};
 }

--- a/immer/detail/rbts/position.hpp
+++ b/immer/detail/rbts/position.hpp
@@ -711,7 +711,7 @@ template <typename NodeT>
 auto make_singleton_regular_sub_pos(NodeT* leaf, count_t count)
 {
     assert(leaf);
-    assert(leaf->kind() == NodeT::kind_t::leaf);
+    assertKind(leaf->kind() == NodeT::kind_t::leaf);
     assert(count > 0);
     return singleton_regular_sub_pos<NodeT>{leaf, count};
 }

--- a/immer/detail/rbts/rbtree.hpp
+++ b/immer/detail/rbts/rbtree.hpp
@@ -443,7 +443,7 @@ struct rbtree
             auto new_root  = get<1>(r);
             auto new_tail  = get<3>(r);
             if (new_root) {
-                assertKind(new_root->compute_shift() == get<0>(r));
+                IMMER_ASSERT_TAGGED(new_root->compute_shift() == get<0>(r));
                 assert(new_root->check(new_shift, new_size - get<2>(r)));
                 return { new_size, new_shift, new_root, new_tail };
             } else {
@@ -520,7 +520,7 @@ struct rbtree
         if (tail_offset() > 0)
             assert(root->check(shift, tail_offset()));
         else {
-            assertKind(root->kind() == node_t::kind_t::inner);
+            IMMER_ASSERT_TAGGED(root->kind() == node_t::kind_t::inner);
             assert(shift == BL);
         }
 #endif

--- a/immer/detail/rbts/rbtree.hpp
+++ b/immer/detail/rbts/rbtree.hpp
@@ -443,7 +443,7 @@ struct rbtree
             auto new_root  = get<1>(r);
             auto new_tail  = get<3>(r);
             if (new_root) {
-                assert(new_root->compute_shift() == get<0>(r));
+                assertKind(new_root->compute_shift() == get<0>(r));
                 assert(new_root->check(new_shift, new_size - get<2>(r)));
                 return { new_size, new_shift, new_root, new_tail };
             } else {

--- a/immer/detail/rbts/rbtree.hpp
+++ b/immer/detail/rbts/rbtree.hpp
@@ -520,7 +520,7 @@ struct rbtree
         if (tail_offset() > 0)
             assert(root->check(shift, tail_offset()));
         else {
-            assert(root->kind() == node_t::kind_t::inner);
+            assertKind(root->kind() == node_t::kind_t::inner);
             assert(shift == BL);
         }
 #endif

--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -1198,7 +1198,7 @@ struct rrbtree
         if (tail_offset() > 0)
             assert(root->check(shift, tail_offset()));
         else {
-            assert(root->kind() == node_t::kind_t::inner);
+            assertKind(root->kind() == node_t::kind_t::inner);
             assert(shift == BL);
         }
 #endif

--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -588,7 +588,7 @@ struct rrbtree
             auto new_root  = get<1>(r);
             auto new_tail  = get<3>(r);
             if (new_root) {
-                assertKind(new_root->compute_shift() == get<0>(r));
+                IMMER_ASSERT_TAGGED(new_root->compute_shift() == get<0>(r));
                 assert(new_root->check(new_shift, new_size - get<2>(r)));
                 return { new_size, new_shift, new_root, new_tail };
             } else {
@@ -706,7 +706,7 @@ struct rrbtree
                                            r.root, r.shift, r.tail_offset());
             auto new_shift  = concated.shift();
             auto new_root   = concated.node();
-            assertKind(new_shift == new_root->compute_shift());
+            IMMER_ASSERT_TAGGED(new_shift == new_root->compute_shift());
             assert(new_root->check(new_shift, size + r.tail_offset()));
             return { size + r.size, new_shift, new_root, r.tail->inc() };
         } else {
@@ -717,7 +717,7 @@ struct rrbtree
                                            r.root, r.shift, r.tail_offset());
             auto new_shift  = concated.shift();
             auto new_root   = concated.node();
-            assertKind(new_shift == new_root->compute_shift());
+            IMMER_ASSERT_TAGGED(new_shift == new_root->compute_shift());
             assert(new_root->check(new_shift, size + r.tail_offset()));
             return { size + r.size, new_shift, new_root, r.tail->inc() };
         }
@@ -782,7 +782,7 @@ struct rrbtree
                     el, l.tail, tail_size,
                     MemoryPolicy::transience_t::noone,
                     r.root, r.shift, r.tail_offset());
-                assertKind(concated.shift() == concated.node()->compute_shift());
+                IMMER_ASSERT_TAGGED(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 l.size += r.size;
                 l.shift = concated.shift();
@@ -806,7 +806,7 @@ struct rrbtree
                     el, l.root, l.shift, tail_offst, l.tail, tail_size,
                     MemoryPolicy::transience_t::noone,
                     r.root, r.shift, r.tail_offset());
-                assertKind(concated.shift() == concated.node()->compute_shift());
+                IMMER_ASSERT_TAGGED(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 l.size += r.size;
                 l.shift = concated.shift();
@@ -897,7 +897,7 @@ struct rrbtree
                     er,
                     MemoryPolicy::transience_t::noone, l.tail, tail_size,
                     er,r.root, r.shift, r.tail_offset());
-                assertKind(concated.shift() == concated.node()->compute_shift());
+                IMMER_ASSERT_TAGGED(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 r.size += l.size;
                 r.shift = concated.shift();
@@ -920,7 +920,7 @@ struct rrbtree
                     MemoryPolicy::transience_t::noone,
                     l.root, l.shift, tail_offst, l.tail, tail_size,
                     er, r.root, r.shift, r.tail_offset());
-                assertKind(concated.shift() == concated.node()->compute_shift());
+                IMMER_ASSERT_TAGGED(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 r.size += l.size;
                 r.shift = concated.shift();
@@ -1004,7 +1004,7 @@ struct rrbtree
                     el,
                     el, l.tail, tail_size,
                     er, r.root, r.shift, r.tail_offset());
-                assertKind(concated.shift() == concated.node()->compute_shift());
+                IMMER_ASSERT_TAGGED(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 l.size += r.size;
                 l.shift = concated.shift();
@@ -1028,7 +1028,7 @@ struct rrbtree
                     el,
                     el, l.root, l.shift, tail_offst, l.tail, tail_size,
                     er, r.root, r.shift, r.tail_offset());
-                assertKind(concated.shift() == concated.node()->compute_shift());
+                IMMER_ASSERT_TAGGED(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 l.size += r.size;
                 l.shift = concated.shift();
@@ -1119,7 +1119,7 @@ struct rrbtree
                     er,
                     el, l.tail, tail_size,
                     er,r.root, r.shift, r.tail_offset());
-                assertKind(concated.shift() == concated.node()->compute_shift());
+                IMMER_ASSERT_TAGGED(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 r.size += l.size;
                 r.shift = concated.shift();
@@ -1142,7 +1142,7 @@ struct rrbtree
                     er,
                     el, l.root, l.shift, tail_offst, l.tail, tail_size,
                     er, r.root, r.shift, r.tail_offset());
-                assertKind(concated.shift() == concated.node()->compute_shift());
+                IMMER_ASSERT_TAGGED(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 r.size += l.size;
                 r.shift = concated.shift();
@@ -1198,7 +1198,7 @@ struct rrbtree
         if (tail_offset() > 0)
             assert(root->check(shift, tail_offset()));
         else {
-            assertKind(root->kind() == node_t::kind_t::inner);
+            IMMER_ASSERT_TAGGED(root->kind() == node_t::kind_t::inner);
             assert(shift == BL);
         }
 #endif

--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -588,7 +588,7 @@ struct rrbtree
             auto new_root  = get<1>(r);
             auto new_tail  = get<3>(r);
             if (new_root) {
-                assert(new_root->compute_shift() == get<0>(r));
+                assertKind(new_root->compute_shift() == get<0>(r));
                 assert(new_root->check(new_shift, new_size - get<2>(r)));
                 return { new_size, new_shift, new_root, new_tail };
             } else {
@@ -706,7 +706,7 @@ struct rrbtree
                                            r.root, r.shift, r.tail_offset());
             auto new_shift  = concated.shift();
             auto new_root   = concated.node();
-            assert(new_shift == new_root->compute_shift());
+            assertKind(new_shift == new_root->compute_shift());
             assert(new_root->check(new_shift, size + r.tail_offset()));
             return { size + r.size, new_shift, new_root, r.tail->inc() };
         } else {
@@ -717,7 +717,7 @@ struct rrbtree
                                            r.root, r.shift, r.tail_offset());
             auto new_shift  = concated.shift();
             auto new_root   = concated.node();
-            assert(new_shift == new_root->compute_shift());
+            assertKind(new_shift == new_root->compute_shift());
             assert(new_root->check(new_shift, size + r.tail_offset()));
             return { size + r.size, new_shift, new_root, r.tail->inc() };
         }
@@ -782,7 +782,7 @@ struct rrbtree
                     el, l.tail, tail_size,
                     MemoryPolicy::transience_t::noone,
                     r.root, r.shift, r.tail_offset());
-                assert(concated.shift() == concated.node()->compute_shift());
+                assertKind(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 l.size += r.size;
                 l.shift = concated.shift();
@@ -806,7 +806,7 @@ struct rrbtree
                     el, l.root, l.shift, tail_offst, l.tail, tail_size,
                     MemoryPolicy::transience_t::noone,
                     r.root, r.shift, r.tail_offset());
-                assert(concated.shift() == concated.node()->compute_shift());
+                assertKind(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 l.size += r.size;
                 l.shift = concated.shift();
@@ -897,7 +897,7 @@ struct rrbtree
                     er,
                     MemoryPolicy::transience_t::noone, l.tail, tail_size,
                     er,r.root, r.shift, r.tail_offset());
-                assert(concated.shift() == concated.node()->compute_shift());
+                assertKind(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 r.size += l.size;
                 r.shift = concated.shift();
@@ -920,7 +920,7 @@ struct rrbtree
                     MemoryPolicy::transience_t::noone,
                     l.root, l.shift, tail_offst, l.tail, tail_size,
                     er, r.root, r.shift, r.tail_offset());
-                assert(concated.shift() == concated.node()->compute_shift());
+                assertKind(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 r.size += l.size;
                 r.shift = concated.shift();
@@ -1004,7 +1004,7 @@ struct rrbtree
                     el,
                     el, l.tail, tail_size,
                     er, r.root, r.shift, r.tail_offset());
-                assert(concated.shift() == concated.node()->compute_shift());
+                assertKind(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 l.size += r.size;
                 l.shift = concated.shift();
@@ -1028,7 +1028,7 @@ struct rrbtree
                     el,
                     el, l.root, l.shift, tail_offst, l.tail, tail_size,
                     er, r.root, r.shift, r.tail_offset());
-                assert(concated.shift() == concated.node()->compute_shift());
+                assertKind(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 l.size += r.size;
                 l.shift = concated.shift();
@@ -1119,7 +1119,7 @@ struct rrbtree
                     er,
                     el, l.tail, tail_size,
                     er,r.root, r.shift, r.tail_offset());
-                assert(concated.shift() == concated.node()->compute_shift());
+                assertKind(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 r.size += l.size;
                 r.shift = concated.shift();
@@ -1142,7 +1142,7 @@ struct rrbtree
                     er,
                     el, l.root, l.shift, tail_offst, l.tail, tail_size,
                     er, r.root, r.shift, r.tail_offset());
-                assert(concated.shift() == concated.node()->compute_shift());
+                assertKind(concated.shift() == concated.node()->compute_shift());
                 assert(concated.node()->check(concated.shift(), l.size + r.tail_offset()));
                 r.size += l.size;
                 r.shift = concated.shift();


### PR DESCRIPTION
It's unfortunate that the data layout of the library depends on the value of the NDEBUG macro, because it makes the code throw an assertion error if a library that includes immer is built with NDEBUG and then an application that includes immer but does not set NDEBUG links against that library. So I moved the functionality to set whether tagged nodes exist into config.hpp, and allowed it to be set by the user. We then create a new macro, assertKind, which we use instead of assert to guard the assertions that depend on tagged nodes.