### PR TITLE
add missing include in flex-vector fuzzer

### DIFF
--- a/extra/fuzzer/flex-vector.cpp
+++ b/extra/fuzzer/flex-vector.cpp
@@ -7,6 +7,7 @@
 //
 
 #include "fuzzer_input.hpp"
+#include <immer/box.hpp>
 #include <immer/flex_vector.hpp>
 #include <iostream>
 #include <array>


### PR DESCRIPTION
A missing header was found while testing immer fuzzers.