### PR TITLE
Fix compilation error when default-initializing array_transient

### DIFF
--- a/immer/array_transient.hpp
+++ b/immer/array_transient.hpp
@@ -186,7 +186,7 @@ private:
         : impl_(std::move(impl))
     {}
 
-    impl_t  impl_  = impl_t::empty;
+    impl_t  impl_  = impl_t::empty();
 };
 
 } // namespace immer

--- a/test/array_transient/default.cpp
+++ b/test/array_transient/default.cpp
@@ -14,6 +14,11 @@
 
 #include "../vector_transient/generic.ipp"
 
+TEST_CASE("array_transient default constructor compiles")
+{
+    immer::array_transient<int> transient;
+}
+
 TEST_CASE("array provides mutable data")
 {
     auto arr = immer::array<int>(10, 0);


### PR DESCRIPTION
Fixes #111.

I've checked that my changes to array_transient.hpp compile. I have not checked that my changes to test/array_transient/default.cpp compile.

as to "why doesn't the compiler complain that the default value is nonsensical, if you don't use the default value?" i have no answer. templates? sfinae?