### PR TITLE
fix a few type conversion warnings

### DIFF
--- a/immer/detail/rbts/bits.hpp
+++ b/immer/detail/rbts/bits.hpp
@@ -16,7 +16,7 @@ namespace rbts {
 
 using bits_t  = std::uint32_t;
 using shift_t = std::uint32_t;
-using count_t = std::uint32_t;
+using count_t = std::size_t;
 using size_t  = std::size_t;
 
 template <bits_t B, typename T=count_t>


### PR DESCRIPTION
This is to address the issue https://github.com/arximboldi/immer/issues/118
All tests with make check passed. Ran with clang-7.1 