### PR TITLE
Minor fixes: MSVC static analysis warnings

### DIFF
--- a/immer/detail/combine_standard_layout.hpp
+++ b/immer/detail/combine_standard_layout.hpp
@@ -10,7 +10,7 @@
 
 #include <type_traits>
 
-#if __GNUC__ == 7 && __GNUC_MINOR__ == 1
+#if defined(__GNUC__) && __GNUC__ == 7 && __GNUC_MINOR__ == 1
 #define IMMER_BROKEN_STANDARD_LAYOUT_DETECTION 1
 #define immer_offsetof(st, m) ((std::size_t) &(((st*)0)->m))
 #else

--- a/immer/detail/iterator_facade.hpp
+++ b/immer/detail/iterator_facade.hpp
@@ -52,12 +52,12 @@ template <typename DerivedT,
           typename DifferenceTypeT = std::ptrdiff_t,
           typename PointerT = T*>
 class iterator_facade
-    : public std::iterator<IteratorCategoryT,
-                           T,
-                           DifferenceTypeT,
-                           PointerT,
-                           ReferenceT>
 {
+  using iterator_category = IteratorCategoryT;
+  using value_type        = T;
+  using difference_type   = DifferenceTypeT;
+  using pointer           = PointerT;
+  using reference         = ReferenceT;
 protected:
     using access_t = iterator_core_access;
 


### PR DESCRIPTION
  - Add defined(__GNUC__) guard to include to avoid "undefined symbol" warning
  - iterator_facade doesn't need to derive from std::iterator; should explicitly define type categories instead