### PR TITLE
Integrate OSS Fuzz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ before_install:
     }
 
 install:
-  - nix upgrade-nix
   - with-nix "echo == nix environment ok"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ git:
 
 matrix:
   include:
-    - env: DO=check TYPE=Debug TOOLCHAIN=llvm-39 SANITIZE=true
-    - env: DO=check TYPE=Release TOOLCHAIN=llvm-39 BENCHMARKS=true
+    - env: DO=check TYPE=Debug TOOLCHAIN=llvm-5 SANITIZE=true
+    - env: DO=check TYPE=Release TOOLCHAIN=llvm-5 BENCHMARKS=true
     - env: DO=check TYPE=Debug TOOLCHAIN=gnu-6 COVERAGE=true
     - env: DO=check TYPE=Release TOOLCHAIN=gnu-6 BENCHMARKS=true
     - env: DO=check TYPE=Debug TOOLCHAIN=gnu-7 STD=17

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - env: DO=check TYPE=Debug TOOLCHAIN=gnu-6 COVERAGE=true
     - env: DO=check TYPE=Release TOOLCHAIN=gnu-6 BENCHMARKS=true
     - env: DO=check TYPE=Debug TOOLCHAIN=gnu-7 STD=17
+    - env: DO=check TYPE=Debug TOOLCHAIN=llvm-8 STD=17 FUZZERS=true
     - env: DO=build
     - env: DO=docs
 
@@ -59,6 +60,7 @@ before_script:
             -DCHECK_BENCHMARKS=${BENCHMARKS} \
             -DENABLE_COVERAGE=${COVERAGE} \
             -DENABLE_SANITIZE=${SANITIZE} \
+            -DCHECK_FUZZERS=${FUZZERS} \
             -DDISABLE_FREE_LIST=${SANITIZE}
     "
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - env: DO=check TYPE=Debug TOOLCHAIN=gnu-6 COVERAGE=true
     - env: DO=check TYPE=Release TOOLCHAIN=gnu-6 BENCHMARKS=true
     - env: DO=check TYPE=Debug TOOLCHAIN=gnu-7 STD=17
-    - env: DO=check TYPE=Debug TOOLCHAIN=llvm-8 STD=17 FUZZERS=true
+    - env: DO=check TYPE=Debug TOOLCHAIN=llvm-9 STD=17 FUZZERS=true
     - env: DO=build
     - env: DO=docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,17 @@ git:
 
 matrix:
   include:
-    - env: DO=check TYPE=Debug COMPILER=clang_39 SANITIZE=true
-    - env: DO=check TYPE=Release COMPILER=clang_39 BENCHMARKS=true
-    - env: DO=check TYPE=Debug COMPILER=gcc6 COVERAGE=true
-    - env: DO=check TYPE=Release COMPILER=gcc6 BENCHMARKS=true
-    - env: DO=check TYPE=Debug COMPILER=gcc7 STD=17
+    - env: DO=check TYPE=Debug TOOLCHAIN=llvm-39 SANITIZE=true
+    - env: DO=check TYPE=Release TOOLCHAIN=llvm-39 BENCHMARKS=true
+    - env: DO=check TYPE=Debug TOOLCHAIN=gnu-6 COVERAGE=true
+    - env: DO=check TYPE=Release TOOLCHAIN=gnu-6 BENCHMARKS=true
+    - env: DO=check TYPE=Debug TOOLCHAIN=gnu-7 STD=17
     - env: DO=build
     - env: DO=docs
 
 before_install:
   - |
-    : ${COMPILER:=gcc6}
+    : ${TOOLCHAIN:=gnu-6}
     : ${TYPE:=Debug}
     : ${STD:=14}
     function build-p { [[ "${DO}" == build ]]; }
@@ -41,7 +41,7 @@ before_install:
         chmod 600 tools/travis/ssh-key
     }
     function with-nix {
-        nix-shell --argstr compiler $COMPILER --run "set -e; $1"
+        nix-shell --argstr toolchain $TOOLCHAIN --run "set -e; $1"
     }
 
 install:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(ENABLE_COVERAGE "compile with test coverage support")
 option(DISABLE_WERROR "enable --werror")
 option(DISABLE_FREE_LIST "disables the free list heap")
 option(DISABLE_THREAD_SAFETY "disables thread safety by default")
+option(CHECK_FUZZERS "Add fuzzers as part of make check")
 
 option(ENABLE_PYTHON "enable building python module" off)
 option(ENABLE_GUILE "enable building guile module" off)

--- a/extra/fuzzer/CMakeLists.txt
+++ b/extra/fuzzer/CMakeLists.txt
@@ -19,18 +19,12 @@ foreach(_file IN LISTS immer_fuzzers)
   immer_target_name_for(_target _output "${_file}")
   add_executable(${_target} EXCLUDE_FROM_ALL "${_file}")
   set_target_properties(${_target} PROPERTIES OUTPUT_NAME ${_output})
-  if (_target MATCHES "-gc$")
-    set(_libs "${BOEHM_GC_LIBRARIES}")
-  endif()
+  target_compile_options(${_target} PUBLIC ${immer_fuzzing_engine})
+  target_link_libraries(${_target} PUBLIC ${immer_fuzzing_engine}
+    immer-dev
+    ${LIBGC_LIBS})
   target_include_directories(${_target} SYSTEM PUBLIC
-    "${BOEHM_GC_INCLUDE_DIR}")
-  target_compile_options(${_target} PUBLIC
-    ${immer_fuzzing_engine}
-    -DIMMER_HAS_LIBGC=1)
-  target_link_libraries(${_target} PUBLIC
-    ${immer_fuzzing_engine}
-    ${_libs}
-    immer)
+    ${LIBGC_INCLUDE_DIR})
   add_dependencies(fuzzers ${_target})
   if (CHECK_FUZZERS)
     add_test("fuzzer/${_output}" ${_output} -max_total_time=1)

--- a/extra/fuzzer/CMakeLists.txt
+++ b/extra/fuzzer/CMakeLists.txt
@@ -6,13 +6,21 @@ if (CHECK_FUZZERS)
   add_dependencies(tests fuzzers)
 endif()
 
+# LIB_FUZZING_ENGINE is set by the Google OSS-Fuzz
+# infrastructure. Otherwise we use Clang's LibFuzzer
+if (DEFINED ENV{LIB_FUZZING_ENGINE})
+  set(immer_fuzzing_engine $ENV{LIB_FUZZING_ENGINE})
+else()
+  set(immer_fuzzing_engine "-fsanitize=fuzzer")
+endif()
+
 file(GLOB_RECURSE immer_fuzzers "*.cpp")
 foreach(_file IN LISTS immer_fuzzers)
   immer_target_name_for(_target _output "${_file}")
   add_executable(${_target} EXCLUDE_FROM_ALL "${_file}")
   set_target_properties(${_target} PROPERTIES OUTPUT_NAME ${_output})
-  target_compile_options(${_target} PUBLIC "-fsanitize=fuzzer")
-  target_link_libraries(${_target} PUBLIC "-fsanitize=fuzzer"
+  target_compile_options(${_target} PUBLIC ${immer_fuzzing_engine})
+  target_link_libraries(${_target} PUBLIC ${immer_fuzzing_engine}
     immer-dev
     ${LIBGC_LIBS})
   target_include_directories(${_target} SYSTEM PUBLIC

--- a/extra/fuzzer/CMakeLists.txt
+++ b/extra/fuzzer/CMakeLists.txt
@@ -21,10 +21,7 @@ foreach(_file IN LISTS immer_fuzzers)
   set_target_properties(${_target} PROPERTIES OUTPUT_NAME ${_output})
   target_compile_options(${_target} PUBLIC ${immer_fuzzing_engine})
   target_link_libraries(${_target} PUBLIC ${immer_fuzzing_engine}
-    immer-dev
-    ${LIBGC_LIBS})
-  target_include_directories(${_target} SYSTEM PUBLIC
-    ${LIBGC_INCLUDE_DIR})
+    immer-dev)
   add_dependencies(fuzzers ${_target})
   if (CHECK_FUZZERS)
     add_test("fuzzer/${_output}" ${_output} -max_total_time=1)

--- a/extra/fuzzer/CMakeLists.txt
+++ b/extra/fuzzer/CMakeLists.txt
@@ -2,6 +2,10 @@
 add_custom_target(fuzzers
   COMMENT "Build all fuzzers.")
 
+if (CHECK_FUZZERS)
+  add_dependencies(tests fuzzers)
+endif()
+
 file(GLOB_RECURSE immer_fuzzers "*.cpp")
 foreach(_file IN LISTS immer_fuzzers)
   immer_target_name_for(_target _output "${_file}")
@@ -14,4 +18,7 @@ foreach(_file IN LISTS immer_fuzzers)
   target_include_directories(${_target} SYSTEM PUBLIC
     ${LIBGC_INCLUDE_DIR})
   add_dependencies(fuzzers ${_target})
+  if (CHECK_FUZZERS)
+    add_test("fuzzer/${_output}" ${_output} -max_total_time=1)
+  endif()
 endforeach()

--- a/extra/fuzzer/CMakeLists.txt
+++ b/extra/fuzzer/CMakeLists.txt
@@ -19,12 +19,18 @@ foreach(_file IN LISTS immer_fuzzers)
   immer_target_name_for(_target _output "${_file}")
   add_executable(${_target} EXCLUDE_FROM_ALL "${_file}")
   set_target_properties(${_target} PROPERTIES OUTPUT_NAME ${_output})
-  target_compile_options(${_target} PUBLIC ${immer_fuzzing_engine})
-  target_link_libraries(${_target} PUBLIC ${immer_fuzzing_engine}
-    immer-dev
-    ${LIBGC_LIBS})
+  if (_target MATCHES "-gc$")
+    set(_libs "${BOEHM_GC_LIBRARIES}")
+  endif()
   target_include_directories(${_target} SYSTEM PUBLIC
-    ${LIBGC_INCLUDE_DIR})
+    "${BOEHM_GC_INCLUDE_DIR}")
+  target_compile_options(${_target} PUBLIC
+    ${immer_fuzzing_engine}
+    -DIMMER_HAS_LIBGC=1)
+  target_link_libraries(${_target} PUBLIC
+    ${immer_fuzzing_engine}
+    ${_libs}
+    immer)
   add_dependencies(fuzzers ${_target})
   if (CHECK_FUZZERS)
     add_test("fuzzer/${_output}" ${_output} -max_total_time=1)

--- a/extra/fuzzer/CMakeLists.txt
+++ b/extra/fuzzer/CMakeLists.txt
@@ -7,13 +7,9 @@ foreach(_file IN LISTS immer_fuzzers)
   immer_target_name_for(_target _output "${_file}")
   add_executable(${_target} EXCLUDE_FROM_ALL "${_file}")
   set_target_properties(${_target} PROPERTIES OUTPUT_NAME ${_output})
-  target_compile_options(${_target} PUBLIC
-    "-fsanitize=address"
-    "-fsanitize-coverage=trace-pc-guard")
-  target_link_libraries(${_target} PUBLIC
-    "-fsanitize=address"
+  target_compile_options(${_target} PUBLIC "-fsanitize=fuzzer")
+  target_link_libraries(${_target} PUBLIC "-fsanitize=fuzzer"
     immer-dev
-    Fuzzer
     ${LIBGC_LIBS})
   target_include_directories(${_target} SYSTEM PUBLIC
     ${LIBGC_INCLUDE_DIR})

--- a/extra/fuzzer/array-gc.cpp
+++ b/extra/fuzzer/array-gc.cpp
@@ -1,0 +1,103 @@
+//
+// immer: immutable data structures for C++
+// Copyright (C) 2016, 2017, 2018 Juan Pedro Bolivar Puente
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include "fuzzer_input.hpp"
+
+#include <immer/array.hpp>
+#include <immer/array_transient.hpp>
+#include <immer/heap/gc_heap.hpp>
+#include <immer/refcount/no_refcount_policy.hpp>
+
+#include <array>
+
+using gc_memory = immer::memory_policy<immer::heap_policy<immer::gc_heap>,
+                                       immer::no_refcount_policy,
+                                       immer::gc_transience_policy,
+                                       false>;
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+                                      std::size_t size)
+{
+    constexpr auto var_count = 4;
+
+    using array_t     = immer::array<int, gc_memory>;
+    using transient_t = typename array_t::transient_type;
+    using size_t      = std::uint8_t;
+
+    auto vs = std::array<array_t, var_count>{};
+    auto ts = std::array<transient_t, var_count>{};
+
+    auto is_valid_var   = [&](auto idx) { return idx >= 0 && idx < var_count; };
+    auto is_valid_index = [](auto& v) {
+        return [&](auto idx) { return idx >= 0 && idx < v.size(); };
+    };
+    auto is_valid_size = [](auto& v) {
+        return [&](auto idx) { return idx >= 0 && idx <= v.size(); };
+    };
+
+    return fuzzer_input{data, size}.run([&](auto& in) {
+        enum ops
+        {
+            op_transient,
+            op_persistent,
+            op_push_back,
+            op_update,
+            op_take,
+            op_push_back_mut,
+            op_update_mut,
+            op_take_mut,
+        };
+        auto dst = read<char>(in, is_valid_var);
+        switch (read<char>(in)) {
+        case op_transient: {
+            auto src = read<char>(in, is_valid_var);
+            ts[dst]  = vs[src].transient();
+            break;
+        }
+        case op_persistent: {
+            auto src = read<char>(in, is_valid_var);
+            vs[dst]  = ts[src].persistent();
+            break;
+        }
+        case op_push_back: {
+            auto src = read<char>(in, is_valid_var);
+            vs[dst]  = vs[src].push_back(42);
+            break;
+        }
+        case op_update: {
+            auto src = read<char>(in, is_valid_var);
+            auto idx = read<size_t>(in, is_valid_index(vs[src]));
+            vs[dst]  = vs[src].update(idx, [](auto x) { return x + 1; });
+            break;
+        }
+        case op_take: {
+            auto src = read<char>(in, is_valid_var);
+            auto idx = read<size_t>(in, is_valid_size(vs[src]));
+            vs[dst]  = vs[src].take(idx);
+            break;
+        }
+        case op_push_back_mut: {
+            ts[dst].push_back(13);
+            break;
+        }
+        case op_update_mut: {
+            auto idx = read<size_t>(in, is_valid_index(ts[dst]));
+            ts[dst].update(idx, [](auto x) { return x + 1; });
+            break;
+        }
+        case op_take_mut: {
+            auto idx = read<size_t>(in, is_valid_size(ts[dst]));
+            ts[dst].take(idx);
+            break;
+        }
+        default:
+            break;
+        };
+        return true;
+    });
+}

--- a/extra/fuzzer/flex-vector-gc.cpp
+++ b/extra/fuzzer/flex-vector-gc.cpp
@@ -7,55 +7,53 @@
 //
 
 #include "fuzzer_input.hpp"
+
 #include <immer/flex_vector.hpp>
 #include <immer/flex_vector_transient.hpp>
 #include <immer/heap/gc_heap.hpp>
 #include <immer/refcount/no_refcount_policy.hpp>
-#include <iostream>
+
 #include <array>
 
-using gc_memory = immer::memory_policy<
-    immer::heap_policy<immer::gc_heap>,
-    immer::no_refcount_policy,
-    immer::gc_transience_policy,
-    false>;
+using gc_memory = immer::memory_policy<immer::heap_policy<immer::gc_heap>,
+                                       immer::no_refcount_policy,
+                                       immer::gc_transience_policy,
+                                       false>;
 
-extern "C"
-int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+                                      std::size_t size)
 {
     constexpr auto var_count = 4;
     constexpr auto bits      = 2;
 
     using vector_t    = immer::flex_vector<int, gc_memory, bits, bits>;
     using transient_t = typename vector_t::transient_type;
-    using size_t   = std::uint8_t;
+    using size_t      = std::uint8_t;
 
     auto vs = std::array<vector_t, var_count>{};
     auto ts = std::array<transient_t, var_count>{};
 
-    auto is_valid_var = [&] (auto idx) {
-        return idx >= 0 && idx < var_count;
-    };
+    auto is_valid_var = [&](auto idx) { return idx >= 0 && idx < var_count; };
     auto is_valid_var_neq = [](auto other) {
-        return [=] (auto idx) {
+        return [=](auto idx) {
             return idx >= 0 && idx < var_count && idx != other;
         };
     };
-    auto is_valid_index = [] (auto& v) {
-        return [&] (auto idx) { return idx >= 0 && idx < v.size(); };
+    auto is_valid_index = [](auto& v) {
+        return [&](auto idx) { return idx >= 0 && idx < v.size(); };
     };
-    auto is_valid_size = [] (auto& v) {
-        return [&] (auto idx) { return idx >= 0 && idx <= v.size(); };
+    auto is_valid_size = [](auto& v) {
+        return [&](auto idx) { return idx >= 0 && idx <= v.size(); };
     };
-    auto can_concat = [] (auto&& v1, auto&& v2) {
+    auto can_concat = [](auto&& v1, auto&& v2) {
         using size_type = decltype(v1.size());
-        auto max = std::numeric_limits<size_type>::max() >> (bits * 4);
+        auto max        = std::numeric_limits<size_type>::max() >> (bits * 4);
         return v1.size() < max && v2.size() < max;
     };
 
-    return fuzzer_input{data, size}.run([&] (auto& in)
-    {
-        enum ops {
+    return fuzzer_input{data, size}.run([&](auto& in) {
+        enum ops
+        {
             op_transient,
             op_persistent,
             op_push_back,
@@ -73,43 +71,42 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
             op_append_mut_move,
         };
         auto dst = read<char>(in, is_valid_var);
-        switch (read<char>(in))
-        {
+        switch (read<char>(in)) {
         case op_transient: {
             auto src = read<char>(in, is_valid_var);
-            ts[dst] = vs[src].transient();
+            ts[dst]  = vs[src].transient();
             break;
         }
         case op_persistent: {
             auto src = read<char>(in, is_valid_var);
-            vs[dst] = ts[src].persistent();
+            vs[dst]  = ts[src].persistent();
             break;
         }
         case op_push_back: {
             auto src = read<char>(in, is_valid_var);
-            vs[dst] = vs[src].push_back(42);
+            vs[dst]  = vs[src].push_back(42);
             break;
         }
         case op_update: {
             auto src = read<char>(in, is_valid_var);
             auto idx = read<size_t>(in, is_valid_index(vs[src]));
-            vs[dst] = vs[src].update(idx, [] (auto x) { return x + 1; });
+            vs[dst]  = vs[src].update(idx, [](auto x) { return x + 1; });
             break;
         }
         case op_take: {
             auto src = read<char>(in, is_valid_var);
             auto idx = read<size_t>(in, is_valid_size(vs[src]));
-            vs[dst] = vs[src].take(idx);
+            vs[dst]  = vs[src].take(idx);
             break;
         }
         case op_drop: {
             auto src = read<char>(in, is_valid_var);
             auto idx = read<size_t>(in, is_valid_size(vs[src]));
-            vs[dst] = vs[src].drop(idx);
+            vs[dst]  = vs[src].drop(idx);
             break;
         }
         case op_concat: {
-            auto src = read<char>(in, is_valid_var);
+            auto src  = read<char>(in, is_valid_var);
             auto src2 = read<char>(in, is_valid_var);
             if (can_concat(vs[src], vs[src2]))
                 vs[dst] = vs[src] + vs[src2];
@@ -121,7 +118,7 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
         }
         case op_update_mut: {
             auto idx = read<size_t>(in, is_valid_index(ts[dst]));
-            ts[dst].update(idx, [] (auto x) { return x + 1; });
+            ts[dst].update(idx, [](auto x) { return x + 1; });
             break;
         }
         case op_take_mut: {

--- a/extra/fuzzer/flex-vector.cpp
+++ b/extra/fuzzer/flex-vector.cpp
@@ -7,44 +7,44 @@
 //
 
 #include "fuzzer_input.hpp"
+
 #include <immer/box.hpp>
 #include <immer/flex_vector.hpp>
-#include <iostream>
+
 #include <array>
 
-extern "C"
-int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+                                      std::size_t size)
 {
     constexpr auto var_count = 8;
     constexpr auto bits      = 2;
 
-    using vector_t = immer::flex_vector<int, immer::default_memory_policy, bits, bits>;
-    using size_t   = std::uint8_t;
+    using vector_t =
+        immer::flex_vector<int, immer::default_memory_policy, bits, bits>;
+    using size_t = std::uint8_t;
 
     auto vars = std::array<vector_t, var_count>{};
 
-    auto is_valid_var = [&] (auto idx) {
-        return idx >= 0 && idx < var_count;
-    };
+    auto is_valid_var = [&](auto idx) { return idx >= 0 && idx < var_count; };
     auto is_valid_var_neq = [](auto other) {
-        return [=] (auto idx) {
+        return [=](auto idx) {
             return idx >= 0 && idx < var_count && idx != other;
         };
     };
-    auto is_valid_index = [] (auto& v) {
-        return [&] (auto idx) { return idx >= 0 && idx < v.size(); };
+    auto is_valid_index = [](auto& v) {
+        return [&](auto idx) { return idx >= 0 && idx < v.size(); };
     };
-    auto is_valid_size = [] (auto& v) {
-        return [&] (auto idx) { return idx >= 0 && idx <= v.size(); };
+    auto is_valid_size = [](auto& v) {
+        return [&](auto idx) { return idx >= 0 && idx <= v.size(); };
     };
-    auto can_concat = [] (auto&& v1, auto&& v2) {
+    auto can_concat = [](auto&& v1, auto&& v2) {
         using size_type = decltype(v1.size());
-        auto max = std::numeric_limits<size_type>::max() >> (bits * 4);
+        auto max        = std::numeric_limits<size_type>::max() >> (bits * 4);
         return v1.size() < max && v2.size() < max;
     };
-    return fuzzer_input{data, size}.run([&] (auto& in)
-    {
-        enum ops {
+    return fuzzer_input{data, size}.run([&](auto& in) {
+        enum ops
+        {
             op_push_back,
             op_update,
             op_take,
@@ -63,24 +63,23 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
         };
         auto src = read<char>(in, is_valid_var);
         auto dst = read<char>(in, is_valid_var);
-        switch (read<char>(in))
-        {
+        switch (read<char>(in)) {
         case op_push_back: {
             vars[dst] = vars[src].push_back(42);
             break;
         }
         case op_update: {
-            auto idx = read<size_t>(in, is_valid_index(vars[src]));
-            vars[dst] = vars[src].update(idx, [] (auto x) { return x + 1; });
+            auto idx  = read<size_t>(in, is_valid_index(vars[src]));
+            vars[dst] = vars[src].update(idx, [](auto x) { return x + 1; });
             break;
         }
         case op_take: {
-            auto idx = read<size_t>(in, is_valid_size(vars[src]));
+            auto idx  = read<size_t>(in, is_valid_size(vars[src]));
             vars[dst] = vars[src].take(idx);
             break;
         }
         case op_drop: {
-            auto idx = read<size_t>(in, is_valid_size(vars[src]));
+            auto idx  = read<size_t>(in, is_valid_size(vars[src]));
             vars[dst] = vars[src].drop(idx);
             break;
         }
@@ -96,17 +95,17 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
         }
         case op_update_move: {
             auto idx = read<size_t>(in, is_valid_index(vars[src]));
-            vars[dst] = std::move(vars[src])
-                .update(idx, [] (auto x) { return x + 1; });
+            vars[dst] =
+                std::move(vars[src]).update(idx, [](auto x) { return x + 1; });
             break;
         }
         case op_take_move: {
-            auto idx = read<size_t>(in, is_valid_size(vars[src]));
+            auto idx  = read<size_t>(in, is_valid_size(vars[src]));
             vars[dst] = std::move(vars[src]).take(idx);
             break;
         }
         case op_drop_move: {
-            auto idx = read<size_t>(in, is_valid_size(vars[src]));
+            auto idx  = read<size_t>(in, is_valid_size(vars[src]));
             vars[dst] = std::move(vars[src]).drop(idx);
             break;
         }
@@ -134,12 +133,12 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
             break;
         }
         case op_erase: {
-            auto idx = read<size_t>(in, is_valid_index(vars[src]));
+            auto idx  = read<size_t>(in, is_valid_index(vars[src]));
             vars[dst] = vars[src].erase(idx);
             break;
         }
         case op_insert: {
-            auto idx = read<size_t>(in, is_valid_size(vars[src]));
+            auto idx  = read<size_t>(in, is_valid_size(vars[src]));
             vars[dst] = vars[src].insert(idx, immer::box<int>{42});
             break;
         }

--- a/extra/fuzzer/fuzzer_input.hpp
+++ b/extra/fuzzer/fuzzer_input.hpp
@@ -8,10 +8,11 @@
 
 #pragma once
 
-#include <stdexcept>
 #include <cstdint>
+#include <stdexcept>
 
-struct no_more_input : std::exception {};
+struct no_more_input : std::exception
+{};
 
 struct fuzzer_input
 {
@@ -20,7 +21,8 @@ struct fuzzer_input
 
     const std::uint8_t* next(std::size_t size)
     {
-        if (size_ < size) throw no_more_input{};
+        if (size_ < size)
+            throw no_more_input{};
         auto r = data_;
         data_ += size;
         size_ -= size;
@@ -30,7 +32,8 @@ struct fuzzer_input
     const std::uint8_t* next(std::size_t size, std::size_t align)
     {
         auto rem = size % align;
-        if (rem) next(align - rem);
+        if (rem)
+            next(align - rem);
         return next(size);
     }
 
@@ -38,7 +41,8 @@ struct fuzzer_input
     int run(Fn step)
     {
         try {
-            while (step(*this));
+            while (step(*this))
+                continue;
         } catch (const no_more_input&) {};
         return 0;
     }
@@ -54,7 +58,5 @@ template <typename T, typename Cond>
 T read(fuzzer_input& fz, Cond cond)
 {
     auto x = read<T>(fz);
-    return cond(x)
-        ? x
-        : read<T>(fz, cond);
+    return cond(x) ? x : read<T>(fz, cond);
 }

--- a/extra/fuzzer/map-gc.cpp
+++ b/extra/fuzzer/map-gc.cpp
@@ -7,34 +7,33 @@
 //
 
 #include "fuzzer_input.hpp"
-#include <immer/map.hpp>
+
 #include <immer/heap/gc_heap.hpp>
+#include <immer/map.hpp>
 #include <immer/refcount/no_refcount_policy.hpp>
-#include <iostream>
+
 #include <array>
 
-using gc_memory = immer::memory_policy<
-    immer::heap_policy<immer::gc_heap>,
-    immer::no_refcount_policy,
-    immer::gc_transience_policy,
-    false>;
+using gc_memory = immer::memory_policy<immer::heap_policy<immer::gc_heap>,
+                                       immer::no_refcount_policy,
+                                       immer::gc_transience_policy,
+                                       false>;
 
-extern "C"
-int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+                                      std::size_t size)
 {
     constexpr auto var_count = 4;
 
-    using map_t = immer::map<char, int, std::hash<char>, std::equal_to<char>, gc_memory>;
+    using map_t =
+        immer::map<char, int, std::hash<char>, std::equal_to<char>, gc_memory>;
 
     auto vars = std::array<map_t, var_count>{};
 
-    auto is_valid_var = [&] (auto idx) {
-        return idx >= 0 && idx < var_count;
-    };
+    auto is_valid_var = [&](auto idx) { return idx >= 0 && idx < var_count; };
 
-    return fuzzer_input{data, size}.run([&] (auto& in)
-    {
-        enum ops {
+    return fuzzer_input{data, size}.run([&](auto& in) {
+        enum ops
+        {
             op_set,
             op_erase,
             op_set_move,
@@ -45,46 +44,45 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
         };
         auto src = read<char>(in, is_valid_var);
         auto dst = read<char>(in, is_valid_var);
-        switch (read<char>(in))
-        {
+        switch (read<char>(in)) {
         case op_set: {
             auto value = read<size_t>(in);
-            vars[dst] = vars[src].set(value, 42);
+            vars[dst]  = vars[src].set(value, 42);
             break;
         }
         case op_erase: {
             auto value = read<size_t>(in);
-            vars[dst] = vars[src].erase(value);
+            vars[dst]  = vars[src].erase(value);
             break;
         }
         case op_set_move: {
             auto value = read<size_t>(in);
-            vars[dst] = std::move(vars[src]).set(value, 42);
+            vars[dst]  = std::move(vars[src]).set(value, 42);
             break;
         }
         case op_erase_move: {
             auto value = read<size_t>(in);
-            vars[dst] = std::move(vars[src]).erase(value);
+            vars[dst]  = std::move(vars[src]).erase(value);
             break;
         }
         case op_iterate: {
             auto srcv = vars[src];
-            for(const auto& v : srcv) {
+            for (const auto& v : srcv) {
                 vars[dst] = vars[dst].set(v.first, v.second);
             }
             break;
         }
         case op_find: {
             auto value = read<size_t>(in);
-            auto res = vars[src].find(value);
-            if(res != nullptr) {
+            auto res   = vars[src].find(value);
+            if (res != nullptr) {
                 vars[dst] = vars[dst].set(*res, 42);
             }
             break;
         }
         case op_update: {
-            auto key = read<size_t>(in);
-            vars[dst] = vars[src].update(key, [](int x) { return x+1; });
+            auto key  = read<size_t>(in);
+            vars[dst] = vars[src].update(key, [](int x) { return x + 1; });
             break;
         }
         default:

--- a/extra/fuzzer/map.cpp
+++ b/extra/fuzzer/map.cpp
@@ -7,12 +7,13 @@
 //
 
 #include "fuzzer_input.hpp"
+
 #include <immer/map.hpp>
-#include <iostream>
+
 #include <array>
 
-extern "C"
-int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+                                      std::size_t size)
 {
     constexpr auto var_count = 4;
 
@@ -20,13 +21,11 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
 
     auto vars = std::array<map_t, var_count>{};
 
-    auto is_valid_var = [&] (auto idx) {
-        return idx >= 0 && idx < var_count;
-    };
+    auto is_valid_var = [&](auto idx) { return idx >= 0 && idx < var_count; };
 
-    return fuzzer_input{data, size}.run([&] (auto& in)
-    {
-        enum ops {
+    return fuzzer_input{data, size}.run([&](auto& in) {
+        enum ops
+        {
             op_set,
             op_erase,
             op_set_move,
@@ -37,46 +36,45 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
         };
         auto src = read<char>(in, is_valid_var);
         auto dst = read<char>(in, is_valid_var);
-        switch (read<char>(in))
-        {
+        switch (read<char>(in)) {
         case op_set: {
             auto value = read<size_t>(in);
-            vars[dst] = vars[src].set(value, 42);
+            vars[dst]  = vars[src].set(value, 42);
             break;
         }
         case op_erase: {
             auto value = read<size_t>(in);
-            vars[dst] = vars[src].erase(value);
+            vars[dst]  = vars[src].erase(value);
             break;
         }
         case op_set_move: {
             auto value = read<size_t>(in);
-            vars[dst] = std::move(vars[src]).set(value, 42);
+            vars[dst]  = std::move(vars[src]).set(value, 42);
             break;
         }
         case op_erase_move: {
             auto value = read<size_t>(in);
-            vars[dst] = std::move(vars[src]).erase(value);
+            vars[dst]  = std::move(vars[src]).erase(value);
             break;
         }
         case op_iterate: {
             auto srcv = vars[src];
-            for(const auto& v : srcv) {
+            for (const auto& v : srcv) {
                 vars[dst] = vars[dst].set(v.first, v.second);
             }
             break;
         }
         case op_find: {
             auto value = read<size_t>(in);
-            auto res = vars[src].find(value);
-            if(res != nullptr) {
+            auto res   = vars[src].find(value);
+            if (res != nullptr) {
                 vars[dst] = vars[dst].set(*res, 42);
             }
             break;
         }
         case op_update: {
-            auto key = read<size_t>(in);
-            vars[dst] = vars[src].update(key, [](int x) { return x+1; });
+            auto key  = read<size_t>(in);
+            vars[dst] = vars[src].update(key, [](int x) { return x + 1; });
             break;
         }
         default:

--- a/extra/fuzzer/set-gc.cpp
+++ b/extra/fuzzer/set-gc.cpp
@@ -7,34 +7,33 @@
 //
 
 #include "fuzzer_input.hpp"
-#include <immer/set.hpp>
+
 #include <immer/heap/gc_heap.hpp>
 #include <immer/refcount/no_refcount_policy.hpp>
-#include <iostream>
+#include <immer/set.hpp>
+
 #include <array>
 
-using gc_memory = immer::memory_policy<
-    immer::heap_policy<immer::gc_heap>,
-    immer::no_refcount_policy,
-    immer::gc_transience_policy,
-    false>;
+using gc_memory = immer::memory_policy<immer::heap_policy<immer::gc_heap>,
+                                       immer::no_refcount_policy,
+                                       immer::gc_transience_policy,
+                                       false>;
 
-extern "C"
-int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+                                      std::size_t size)
 {
     constexpr auto var_count = 4;
 
-    using set_t= immer::set<int, std::hash<char>, std::equal_to<char>, gc_memory>;
+    using set_t =
+        immer::set<int, std::hash<char>, std::equal_to<char>, gc_memory>;
 
     auto vars = std::array<set_t, var_count>{};
 
-    auto is_valid_var = [&] (auto idx) {
-        return idx >= 0 && idx < var_count;
-    };
+    auto is_valid_var = [&](auto idx) { return idx >= 0 && idx < var_count; };
 
-    return fuzzer_input{data, size}.run([&] (auto& in)
-    {
-        enum ops {
+    return fuzzer_input{data, size}.run([&](auto& in) {
+        enum ops
+        {
             op_insert,
             op_erase,
             op_insert_move,
@@ -43,31 +42,30 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
         };
         auto src = read<char>(in, is_valid_var);
         auto dst = read<char>(in, is_valid_var);
-        switch (read<char>(in))
-        {
+        switch (read<char>(in)) {
         case op_insert: {
             auto value = read<size_t>(in);
-            vars[dst] = vars[src].insert(value);
+            vars[dst]  = vars[src].insert(value);
             break;
         }
         case op_erase: {
             auto value = read<size_t>(in);
-            vars[dst] = vars[src].erase(value);
+            vars[dst]  = vars[src].erase(value);
             break;
         }
         case op_insert_move: {
             auto value = read<size_t>(in);
-            vars[dst] = std::move(vars[src]).insert(value);
+            vars[dst]  = std::move(vars[src]).insert(value);
             break;
         }
         case op_erase_move: {
             auto value = read<size_t>(in);
-            vars[dst] = vars[src].erase(value);
+            vars[dst]  = vars[src].erase(value);
             break;
         }
         case op_iterate: {
             auto srcv = vars[src];
-            for(const auto &v : srcv) {
+            for (const auto& v : srcv) {
                 vars[dst] = vars[dst].insert(v);
             }
             break;

--- a/extra/fuzzer/set.cpp
+++ b/extra/fuzzer/set.cpp
@@ -7,26 +7,25 @@
 //
 
 #include "fuzzer_input.hpp"
+
 #include <immer/set.hpp>
-#include <iostream>
+
 #include <array>
 
-extern "C"
-int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+                                      std::size_t size)
 {
     constexpr auto var_count = 4;
 
-    using set_t= immer::set<int>;
+    using set_t = immer::set<int>;
 
     auto vars = std::array<set_t, var_count>{};
 
-    auto is_valid_var = [&] (auto idx) {
-        return idx >= 0 && idx < var_count;
-    };
+    auto is_valid_var = [&](auto idx) { return idx >= 0 && idx < var_count; };
 
-    return fuzzer_input{data, size}.run([&] (auto& in)
-    {
-        enum ops {
+    return fuzzer_input{data, size}.run([&](auto& in) {
+        enum ops
+        {
             op_insert,
             op_erase,
             op_insert_move,
@@ -35,31 +34,30 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
         };
         auto src = read<char>(in, is_valid_var);
         auto dst = read<char>(in, is_valid_var);
-        switch (read<char>(in))
-        {
+        switch (read<char>(in)) {
         case op_insert: {
             auto value = read<size_t>(in);
-            vars[dst] = vars[src].insert(value);
+            vars[dst]  = vars[src].insert(value);
             break;
         }
         case op_erase: {
             auto value = read<size_t>(in);
-            vars[dst] = vars[src].erase(value);
+            vars[dst]  = vars[src].erase(value);
             break;
         }
         case op_insert_move: {
             auto value = read<size_t>(in);
-            vars[dst] = std::move(vars[src]).insert(value);
+            vars[dst]  = std::move(vars[src]).insert(value);
             break;
         }
         case op_erase_move: {
             auto value = read<size_t>(in);
-            vars[dst] = vars[src].erase(value);
+            vars[dst]  = vars[src].erase(value);
             break;
         }
         case op_iterate: {
             auto srcv = vars[src];
-            for(const auto &v : srcv) {
+            for (const auto& v : srcv) {
                 vars[dst] = vars[dst].insert(v);
             }
             break;

--- a/extra/fuzzer/vector-gc.cpp
+++ b/extra/fuzzer/vector-gc.cpp
@@ -7,45 +7,43 @@
 //
 
 #include "fuzzer_input.hpp"
-#include <immer/vector.hpp>
-#include <immer/vector_transient.hpp>
+
 #include <immer/heap/gc_heap.hpp>
 #include <immer/refcount/no_refcount_policy.hpp>
-#include <iostream>
+#include <immer/vector.hpp>
+#include <immer/vector_transient.hpp>
+
 #include <array>
 
-using gc_memory = immer::memory_policy<
-    immer::heap_policy<immer::gc_heap>,
-    immer::no_refcount_policy,
-    immer::gc_transience_policy,
-    false>;
+using gc_memory = immer::memory_policy<immer::heap_policy<immer::gc_heap>,
+                                       immer::no_refcount_policy,
+                                       immer::gc_transience_policy,
+                                       false>;
 
-extern "C"
-int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+                                      std::size_t size)
 {
     constexpr auto var_count = 4;
     constexpr auto bits      = 2;
 
     using vector_t    = immer::vector<int, gc_memory, bits, bits>;
     using transient_t = typename vector_t::transient_type;
-    using size_t   = std::uint8_t;
+    using size_t      = std::uint8_t;
 
     auto vs = std::array<vector_t, var_count>{};
     auto ts = std::array<transient_t, var_count>{};
 
-    auto is_valid_var = [&] (auto idx) {
-        return idx >= 0 && idx < var_count;
+    auto is_valid_var   = [&](auto idx) { return idx >= 0 && idx < var_count; };
+    auto is_valid_index = [](auto& v) {
+        return [&](auto idx) { return idx >= 0 && idx < v.size(); };
     };
-    auto is_valid_index = [] (auto& v) {
-        return [&] (auto idx) { return idx >= 0 && idx < v.size(); };
-    };
-    auto is_valid_size = [] (auto& v) {
-        return [&] (auto idx) { return idx >= 0 && idx <= v.size(); };
+    auto is_valid_size = [](auto& v) {
+        return [&](auto idx) { return idx >= 0 && idx <= v.size(); };
     };
 
-    return fuzzer_input{data, size}.run([&] (auto& in)
-    {
-        enum ops {
+    return fuzzer_input{data, size}.run([&](auto& in) {
+        enum ops
+        {
             op_transient,
             op_persistent,
             op_push_back,
@@ -56,33 +54,32 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
             op_take_mut,
         };
         auto dst = read<char>(in, is_valid_var);
-        switch (read<char>(in))
-        {
+        switch (read<char>(in)) {
         case op_transient: {
             auto src = read<char>(in, is_valid_var);
-            ts[dst] = vs[src].transient();
+            ts[dst]  = vs[src].transient();
             break;
         }
         case op_persistent: {
             auto src = read<char>(in, is_valid_var);
-            vs[dst] = ts[src].persistent();
+            vs[dst]  = ts[src].persistent();
             break;
         }
         case op_push_back: {
             auto src = read<char>(in, is_valid_var);
-            vs[dst] = vs[src].push_back(42);
+            vs[dst]  = vs[src].push_back(42);
             break;
         }
         case op_update: {
             auto src = read<char>(in, is_valid_var);
             auto idx = read<size_t>(in, is_valid_index(vs[src]));
-            vs[dst] = vs[src].update(idx, [] (auto x) { return x + 1; });
+            vs[dst]  = vs[src].update(idx, [](auto x) { return x + 1; });
             break;
         }
         case op_take: {
             auto src = read<char>(in, is_valid_var);
             auto idx = read<size_t>(in, is_valid_size(vs[src]));
-            vs[dst] = vs[src].take(idx);
+            vs[dst]  = vs[src].take(idx);
             break;
         }
         case op_push_back_mut: {
@@ -91,7 +88,7 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
         }
         case op_update_mut: {
             auto idx = read<size_t>(in, is_valid_index(ts[dst]));
-            ts[dst].update(idx, [] (auto x) { return x + 1; });
+            ts[dst].update(idx, [](auto x) { return x + 1; });
             break;
         }
         case op_take_mut: {

--- a/extra/fuzzer/vector.cpp
+++ b/extra/fuzzer/vector.cpp
@@ -7,34 +7,34 @@
 //
 
 #include "fuzzer_input.hpp"
+
 #include <immer/vector.hpp>
-#include <iostream>
+
 #include <array>
 
-extern "C"
-int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+                                      std::size_t size)
 {
     constexpr auto var_count = 4;
     constexpr auto bits      = 2;
 
-    using vector_t = immer::vector<int, immer::default_memory_policy, bits, bits>;
-    using size_t   = std::uint8_t;
+    using vector_t =
+        immer::vector<int, immer::default_memory_policy, bits, bits>;
+    using size_t = std::uint8_t;
 
     auto vars = std::array<vector_t, var_count>{};
 
-    auto is_valid_var = [&] (auto idx) {
-        return idx >= 0 && idx < var_count;
+    auto is_valid_var   = [&](auto idx) { return idx >= 0 && idx < var_count; };
+    auto is_valid_index = [](auto& v) {
+        return [&](auto idx) { return idx >= 0 && idx < v.size(); };
     };
-    auto is_valid_index = [] (auto& v) {
-        return [&] (auto idx) { return idx >= 0 && idx < v.size(); };
-    };
-    auto is_valid_size = [] (auto& v) {
-        return [&] (auto idx) { return idx >= 0 && idx <= v.size(); };
+    auto is_valid_size = [](auto& v) {
+        return [&](auto idx) { return idx >= 0 && idx <= v.size(); };
     };
 
-    return fuzzer_input{data, size}.run([&] (auto& in)
-    {
-        enum ops {
+    return fuzzer_input{data, size}.run([&](auto& in) {
+        enum ops
+        {
             op_push_back,
             op_update,
             op_take,
@@ -44,19 +44,18 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
         };
         auto src = read<char>(in, is_valid_var);
         auto dst = read<char>(in, is_valid_var);
-        switch (read<char>(in))
-        {
+        switch (read<char>(in)) {
         case op_push_back: {
             vars[dst] = vars[src].push_back(42);
             break;
         }
         case op_update: {
-            auto idx = read<size_t>(in, is_valid_index(vars[src]));
-            vars[dst] = vars[src].update(idx, [] (auto x) { return x + 1; });
+            auto idx  = read<size_t>(in, is_valid_index(vars[src]));
+            vars[dst] = vars[src].update(idx, [](auto x) { return x + 1; });
             break;
         }
         case op_take: {
-            auto idx = read<size_t>(in, is_valid_size(vars[src]));
+            auto idx  = read<size_t>(in, is_valid_size(vars[src]));
             vars[dst] = vars[src].take(idx);
             break;
         }
@@ -66,12 +65,12 @@ int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
         }
         case op_update_move: {
             auto idx = read<size_t>(in, is_valid_index(vars[src]));
-            vars[dst] = std::move(vars[src])
-                .update(idx, [] (auto x) { return x + 1; });
+            vars[dst] =
+                std::move(vars[src]).update(idx, [](auto x) { return x + 1; });
             break;
         }
         case op_take_move: {
-            auto idx = read<size_t>(in, is_valid_size(vars[src]));
+            auto idx  = read<size_t>(in, is_valid_size(vars[src]));
             vars[dst] = std::move(vars[src]).take(idx);
             break;
         }


### PR DESCRIPTION
In order to address #102, working towards ideal integration, we first do some build system changes to:
1. Make it easier to build the fuzzers from oss-fuzz, such that `make fuzzers` suffices and builds all fuzzers, automatically using the OSS Fuzz provided fuzzer engine if available
2. Make sure fuzzers are also built and minimally tested on our Travis CI

FYI @luismerino 