### PR TITLE
Make excpetions optional depending on build-time feature checks.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -18,6 +18,7 @@ ColumnLimit: '80'
 CompactNamespaces: 'false'
 ConstructorInitializerAllOnOneLineOrOnePerLine: 'false'
 FixNamespaceComments: 'true'
+ForEachMacros: ['IMMER_CATCH', 'IMMER_TRY']
 IndentCaseLabels: 'false'
 IndentWidth: '4'
 IndentWrappedFunctionNames: 'false'

--- a/immer/config.hpp
+++ b/immer/config.hpp
@@ -18,6 +18,28 @@
 #endif
 #endif
 
+#ifdef __has_feature
+#if !__has_feature(cxx_exceptions)
+#define IMMER_NO_EXCEPTIONS
+#endif
+#endif
+
+#ifdef IMMER_NO_EXCEPTIONS
+#define IMMER_TRY if (true)
+#define IMMER_CATCH(expr) else
+#define IMMER_THROW(expr) \
+    do {                  \
+        assert(! #expr);  \
+        std::terminate(); \
+    } while(false)
+#define IMMER_RETHROW
+#else
+#define IMMER_TRY try
+#define IMMER_CATCH(expr) catch (expr)
+#define IMMER_THROW(expr) throw expr
+#define IMMER_RETHROW throw
+#endif
+
 #ifndef IMMER_NODISCARD
 #define IMMER_NODISCARD
 #endif

--- a/immer/config.hpp
+++ b/immer/config.hpp
@@ -27,11 +27,11 @@
 #ifdef IMMER_NO_EXCEPTIONS
 #define IMMER_TRY if (true)
 #define IMMER_CATCH(expr) else
-#define IMMER_THROW(expr) \
-    do {                  \
-        assert(! #expr);  \
-        std::terminate(); \
-    } while(false)
+#define IMMER_THROW(expr)                                                      \
+    do {                                                                       \
+        assert(!#expr);                                                        \
+        std::terminate();                                                      \
+    } while (false)
 #define IMMER_RETHROW
 #else
 #define IMMER_TRY try

--- a/immer/detail/arrays/no_capacity.hpp
+++ b/immer/detail/arrays/no_capacity.hpp
@@ -11,6 +11,9 @@
 #include <immer/algorithm.hpp>
 #include <immer/detail/arrays/node.hpp>
 
+#include <cassert>
+#include <exception>
+
 namespace immer {
 namespace detail {
 namespace arrays {
@@ -142,7 +145,7 @@ struct no_capacity
     const T& get_check(std::size_t index) const
     {
         if (index >= size)
-            throw std::out_of_range{"out of range"};
+            IMMER_THROW(std::out_of_range{"out of range"});
         return data()[index];
     }
 
@@ -156,24 +159,24 @@ struct no_capacity
     no_capacity push_back(T value) const
     {
         auto p = node_t::copy_n(size + 1, ptr, size);
-        try {
+        IMMER_TRY {
             new (p->data() + size) T{std::move(value)};
             return {p, size + 1};
-        } catch (...) {
+        } IMMER_CATCH (...) {
             node_t::delete_n(p, size, size + 1);
-            throw;
+            IMMER_RETHROW;
         }
     }
 
     no_capacity assoc(std::size_t idx, T value) const
     {
         auto p = node_t::copy_n(size, ptr, size);
-        try {
+        IMMER_TRY {
             p->data()[idx] = std::move(value);
             return {p, size};
-        } catch (...) {
+        } IMMER_CATCH (...) {
             node_t::delete_n(p, size, size);
-            throw;
+            IMMER_RETHROW;
         }
     }
 
@@ -181,13 +184,13 @@ struct no_capacity
     no_capacity update(std::size_t idx, Fn&& op) const
     {
         auto p = node_t::copy_n(size, ptr, size);
-        try {
+        IMMER_TRY {
             auto& elem = p->data()[idx];
             elem       = std::forward<Fn>(op)(std::move(elem));
             return {p, size};
-        } catch (...) {
+        } IMMER_CATCH (...) {
             node_t::delete_n(p, size, size);
-            throw;
+            IMMER_RETHROW;
         }
     }
 

--- a/immer/detail/arrays/no_capacity.hpp
+++ b/immer/detail/arrays/no_capacity.hpp
@@ -162,7 +162,8 @@ struct no_capacity
         IMMER_TRY {
             new (p->data() + size) T{std::move(value)};
             return {p, size + 1};
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             node_t::delete_n(p, size, size + 1);
             IMMER_RETHROW;
         }
@@ -174,7 +175,8 @@ struct no_capacity
         IMMER_TRY {
             p->data()[idx] = std::move(value);
             return {p, size};
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             node_t::delete_n(p, size, size);
             IMMER_RETHROW;
         }
@@ -188,7 +190,8 @@ struct no_capacity
             auto& elem = p->data()[idx];
             elem       = std::forward<Fn>(op)(std::move(elem));
             return {p, size};
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             node_t::delete_n(p, size, size);
             IMMER_RETHROW;
         }

--- a/immer/detail/arrays/node.hpp
+++ b/immer/detail/arrays/node.hpp
@@ -78,12 +78,12 @@ struct node
     static node_t* fill_n(size_t n, T v)
     {
         auto p = make_n(n);
-        try {
+        IMMER_TRY {
             std::uninitialized_fill_n(p->data(), n, v);
             return p;
-        } catch (...) {
+        } IMMER_CATCH (...) {
             heap::deallocate(sizeof_n(n), p);
-            throw;
+            IMMER_RETHROW;
         }
     }
 
@@ -94,12 +94,12 @@ struct node
     static node_t* copy_n(size_t n, Iter first, Sent last)
     {
         auto p = make_n(n);
-        try {
+        IMMER_TRY {
             uninitialized_copy(first, last, p->data());
             return p;
-        } catch (...) {
+        } IMMER_CATCH (...) {
             heap::deallocate(sizeof_n(n), p);
-            throw;
+            IMMER_RETHROW;
         }
     }
 

--- a/immer/detail/arrays/node.hpp
+++ b/immer/detail/arrays/node.hpp
@@ -81,7 +81,8 @@ struct node
         IMMER_TRY {
             std::uninitialized_fill_n(p->data(), n, v);
             return p;
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             heap::deallocate(sizeof_n(n), p);
             IMMER_RETHROW;
         }
@@ -97,7 +98,8 @@ struct node
         IMMER_TRY {
             uninitialized_copy(first, last, p->data());
             return p;
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             heap::deallocate(sizeof_n(n), p);
             IMMER_RETHROW;
         }

--- a/immer/detail/arrays/with_capacity.hpp
+++ b/immer/detail/arrays/with_capacity.hpp
@@ -196,7 +196,8 @@ struct with_capacity
         IMMER_TRY {
             new (p->data() + size) T{std::move(value)};
             return {p, size + 1, cap};
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             node_t::delete_n(p, size, cap);
             IMMER_RETHROW;
         }
@@ -213,7 +214,8 @@ struct with_capacity
             IMMER_TRY {
                 new (p->data() + size) T{std::move(value)};
                 *this = {p, size + 1, cap};
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 node_t::delete_n(p, size, cap);
                 IMMER_RETHROW;
             }
@@ -226,7 +228,8 @@ struct with_capacity
         IMMER_TRY {
             p->data()[idx] = std::move(value);
             return {p, size, capacity};
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             node_t::delete_n(p, size, capacity);
             IMMER_RETHROW;
         }
@@ -241,7 +244,8 @@ struct with_capacity
             IMMER_TRY {
                 p->data()[idx] = std::move(value);
                 *this          = {p, size, capacity};
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 node_t::delete_n(p, size, capacity);
                 IMMER_RETHROW;
             }
@@ -256,7 +260,8 @@ struct with_capacity
             auto& elem = p->data()[idx];
             elem       = std::forward<Fn>(op)(std::move(elem));
             return {p, size, capacity};
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             node_t::delete_n(p, size, capacity);
             IMMER_RETHROW;
         }
@@ -274,7 +279,8 @@ struct with_capacity
                 auto& elem = p->data()[idx];
                 elem       = std::forward<Fn>(op)(std::move(elem));
                 *this      = {p, size, capacity};
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 node_t::delete_n(p, size, capacity);
                 IMMER_RETHROW;
             }

--- a/immer/detail/arrays/with_capacity.hpp
+++ b/immer/detail/arrays/with_capacity.hpp
@@ -10,6 +10,9 @@
 
 #include <immer/detail/arrays/no_capacity.hpp>
 
+#include <cassert>
+#include <exception>
+
 namespace immer {
 namespace detail {
 namespace arrays {
@@ -159,7 +162,7 @@ struct with_capacity
     const T& get_check(std::size_t index) const
     {
         if (index >= size)
-            throw std::out_of_range{"out of range"};
+            IMMER_THROW(std::out_of_range{"out of range"});
         return data()[index];
     }
 
@@ -190,12 +193,12 @@ struct with_capacity
     {
         auto cap = recommend_up(size + 1, capacity);
         auto p   = node_t::copy_n(cap, ptr, size);
-        try {
+        IMMER_TRY {
             new (p->data() + size) T{std::move(value)};
             return {p, size + 1, cap};
-        } catch (...) {
+        } IMMER_CATCH (...) {
             node_t::delete_n(p, size, cap);
-            throw;
+            IMMER_RETHROW;
         }
     }
 
@@ -207,12 +210,12 @@ struct with_capacity
         } else {
             auto cap = recommend_up(size + 1, capacity);
             auto p   = node_t::copy_e(e, cap, ptr, size);
-            try {
+            IMMER_TRY {
                 new (p->data() + size) T{std::move(value)};
                 *this = {p, size + 1, cap};
-            } catch (...) {
+            } IMMER_CATCH (...) {
                 node_t::delete_n(p, size, cap);
-                throw;
+                IMMER_RETHROW;
             }
         }
     }
@@ -220,12 +223,12 @@ struct with_capacity
     with_capacity assoc(std::size_t idx, T value) const
     {
         auto p = node_t::copy_n(capacity, ptr, size);
-        try {
+        IMMER_TRY {
             p->data()[idx] = std::move(value);
             return {p, size, capacity};
-        } catch (...) {
+        } IMMER_CATCH (...) {
             node_t::delete_n(p, size, capacity);
-            throw;
+            IMMER_RETHROW;
         }
     }
 
@@ -235,12 +238,12 @@ struct with_capacity
             data()[idx] = std::move(value);
         } else {
             auto p = node_t::copy_n(capacity, ptr, size);
-            try {
+            IMMER_TRY {
                 p->data()[idx] = std::move(value);
                 *this          = {p, size, capacity};
-            } catch (...) {
+            } IMMER_CATCH (...) {
                 node_t::delete_n(p, size, capacity);
-                throw;
+                IMMER_RETHROW;
             }
         }
     }
@@ -249,13 +252,13 @@ struct with_capacity
     with_capacity update(std::size_t idx, Fn&& op) const
     {
         auto p = node_t::copy_n(capacity, ptr, size);
-        try {
+        IMMER_TRY {
             auto& elem = p->data()[idx];
             elem       = std::forward<Fn>(op)(std::move(elem));
             return {p, size, capacity};
-        } catch (...) {
+        } IMMER_CATCH (...) {
             node_t::delete_n(p, size, capacity);
-            throw;
+            IMMER_RETHROW;
         }
     }
 
@@ -267,13 +270,13 @@ struct with_capacity
             elem       = std::forward<Fn>(op)(std::move(elem));
         } else {
             auto p = node_t::copy_e(e, capacity, ptr, size);
-            try {
+            IMMER_TRY {
                 auto& elem = p->data()[idx];
                 elem       = std::forward<Fn>(op)(std::move(elem));
                 *this      = {p, size, capacity};
-            } catch (...) {
+            } IMMER_CATCH (...) {
                 node_t::delete_n(p, size, capacity);
-                throw;
+                IMMER_RETHROW;
             }
         }
     }

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -171,7 +171,8 @@ struct champ
                     result.first =
                         node_t::copy_inner_replace(node, offset, result.first);
                     return result;
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     node_t::delete_deep_shift(result.first, shift + B);
                     IMMER_RETHROW;
                 }
@@ -189,7 +190,8 @@ struct champ
                         return {node_t::copy_inner_replace_merged(
                                     node, bit, offset, child),
                                 true};
-                    } IMMER_CATCH (...) {
+                    }
+                    IMMER_CATCH (...) {
                         node_t::delete_deep_shift(child, shift + B);
                         IMMER_RETHROW;
                     }
@@ -250,7 +252,8 @@ struct champ
                     result.first =
                         node_t::copy_inner_replace(node, offset, result.first);
                     return result;
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     node_t::delete_deep_shift(result.first, shift + B);
                     IMMER_RETHROW;
                 }
@@ -277,7 +280,8 @@ struct champ
                         return {node_t::copy_inner_replace_merged(
                                     node, bit, offset, child),
                                 true};
-                    } IMMER_CATCH (...) {
+                    }
+                    IMMER_CATCH (...) {
                         node_t::delete_deep_shift(child, shift + B);
                         IMMER_RETHROW;
                     }
@@ -375,7 +379,8 @@ struct champ
                     IMMER_TRY {
                         return node_t::copy_inner_replace(
                             node, offset, result.data.tree);
-                    } IMMER_CATCH (...) {
+                    }
+                    IMMER_CATCH (...) {
                         node_t::delete_deep_shift(result.data.tree, shift + B);
                         IMMER_RETHROW;
                     }

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -167,13 +167,13 @@ struct champ
                 assert(node->children()[offset]);
                 auto result = do_add(
                     node->children()[offset], std::move(v), hash, shift + B);
-                try {
+                IMMER_TRY {
                     result.first =
                         node_t::copy_inner_replace(node, offset, result.first);
                     return result;
-                } catch (...) {
+                } IMMER_CATCH (...) {
                     node_t::delete_deep_shift(result.first, shift + B);
-                    throw;
+                    IMMER_RETHROW;
                 }
             } else if (node->datamap() & bit) {
                 auto offset = node->data_count(bit);
@@ -185,13 +185,13 @@ struct champ
                 else {
                     auto child = node_t::make_merged(
                         shift + B, std::move(v), hash, *val, Hash{}(*val));
-                    try {
+                    IMMER_TRY {
                         return {node_t::copy_inner_replace_merged(
                                     node, bit, offset, child),
                                 true};
-                    } catch (...) {
+                    } IMMER_CATCH (...) {
                         node_t::delete_deep_shift(child, shift + B);
-                        throw;
+                        IMMER_RETHROW;
                     }
                 }
             } else {
@@ -246,13 +246,13 @@ struct champ
                     std::forward<Fn>(fn),
                     hash,
                     shift + B);
-                try {
+                IMMER_TRY {
                     result.first =
                         node_t::copy_inner_replace(node, offset, result.first);
                     return result;
-                } catch (...) {
+                } IMMER_CATCH (...) {
                     node_t::delete_deep_shift(result.first, shift + B);
-                    throw;
+                    IMMER_RETHROW;
                 }
             } else if (node->datamap() & bit) {
                 auto offset = node->data_count(bit);
@@ -273,13 +273,13 @@ struct champ
                         hash,
                         *val,
                         Hash{}(*val));
-                    try {
+                    IMMER_TRY {
                         return {node_t::copy_inner_replace_merged(
                                     node, bit, offset, child),
                                 true};
-                    } catch (...) {
+                    } IMMER_CATCH (...) {
                         node_t::delete_deep_shift(child, shift + B);
-                        throw;
+                        IMMER_RETHROW;
                     }
                 }
             } else {
@@ -372,12 +372,12 @@ struct champ
                                : node_t::copy_inner_replace_inline(
                                      node, bit, offset, *result.data.singleton);
                 case sub_result::tree:
-                    try {
+                    IMMER_TRY {
                         return node_t::copy_inner_replace(
                             node, offset, result.data.tree);
-                    } catch (...) {
+                    } IMMER_CATCH (...) {
                         node_t::delete_deep_shift(result.data.tree, shift + B);
-                        throw;
+                        IMMER_RETHROW;
                     }
                 }
             } else if (node->datamap() & bit) {

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -235,7 +235,8 @@ struct node
             IMMER_TRY {
                 p->impl.d.data.inner.values =
                     new (heap::allocate(sizeof_values_n(nv))) values_t{};
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 deallocate_inner(p, n);
                 IMMER_RETHROW;
             }
@@ -258,7 +259,8 @@ struct node
         p->impl.d.data.inner.datamap = bitmap;
         IMMER_TRY {
             new (p->values()) T{std::move(x)};
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             deallocate_inner(p, n, 1);
             IMMER_RETHROW;
         }
@@ -278,11 +280,13 @@ struct node
                 new (vp) T{std::move(x1)};
                 IMMER_TRY {
                     new (vp + 1) T{std::move(x2)};
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     vp->~T();
                     IMMER_RETHROW;
                 }
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 deallocate_inner(p, n, 2);
                 IMMER_RETHROW;
             }
@@ -318,11 +322,13 @@ struct node
             new (cols) T{std::move(v1)};
             IMMER_TRY {
                 new (cols + 1) T{std::move(v2)};
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 cols->~T();
                 IMMER_RETHROW;
             }
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             deallocate_collision(p, 2);
             IMMER_RETHROW;
         }
@@ -340,11 +346,13 @@ struct node
             new (dstp) T{std::move(v)};
             IMMER_TRY {
                 std::uninitialized_copy(srcp, srcp + n, dstp + 1);
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 dstp->~T();
                 IMMER_RETHROW;
             }
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             deallocate_collision(dst, n + 1);
             IMMER_RETHROW;
         }
@@ -363,11 +371,13 @@ struct node
             dstp = std::uninitialized_copy(srcp, v, dstp);
             IMMER_TRY {
                 std::uninitialized_copy(v + 1, srcp + n, dstp);
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 destroy(dst->collisions(), dstp);
                 IMMER_RETHROW;
             }
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             deallocate_collision(dst, n - 1);
             IMMER_RETHROW;
         }
@@ -388,15 +398,18 @@ struct node
                 dstp = std::uninitialized_copy(srcp, pos, dstp + 1);
                 IMMER_TRY {
                     std::uninitialized_copy(pos + 1, srcp + n, dstp);
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     destroy(dst->collisions(), dstp);
                     IMMER_RETHROW;
                 }
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 dst->collisions()->~T();
                 IMMER_RETHROW;
             }
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             deallocate_collision(dst, n);
             IMMER_RETHROW;
         }
@@ -434,11 +447,13 @@ struct node
                 src->values(), src->values() + nv, dst->values());
             IMMER_TRY {
                 dst->values()[offset] = std::move(v);
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 destroy_n(dst->values(), nv);
                 IMMER_RETHROW;
             }
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             deallocate_inner(dst, n, nv);
             IMMER_RETHROW;
         }
@@ -471,11 +486,13 @@ struct node
                     std::uninitialized_copy(src->values() + voffset + 1,
                                             src->values() + nv,
                                             dst->values() + voffset);
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     destroy_n(dst->values(), voffset);
                     IMMER_RETHROW;
                 }
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 deallocate_inner(dst, n + 1, nv - 1);
                 IMMER_RETHROW;
             }
@@ -516,15 +533,18 @@ struct node
                         std::uninitialized_copy(src->values() + voffset,
                                                 src->values() + nv,
                                                 dst->values() + voffset + 1);
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     dst->values()[voffset].~T();
                     IMMER_RETHROW;
                 }
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 destroy_n(dst->values(), voffset);
                 IMMER_RETHROW;
             }
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             deallocate_inner(dst, n - 1, nv + 1);
             IMMER_RETHROW;
         }
@@ -558,11 +578,13 @@ struct node
                     std::uninitialized_copy(src->values() + voffset + 1,
                                             src->values() + nv,
                                             dst->values() + voffset);
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     destroy_n(dst->values(), voffset);
                     IMMER_RETHROW;
                 }
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 deallocate_inner(dst, n, nv - 1);
                 IMMER_RETHROW;
             }
@@ -593,15 +615,18 @@ struct node
                         std::uninitialized_copy(src->values() + offset,
                                                 src->values() + nv,
                                                 dst->values() + offset + 1);
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     dst->values()[offset].~T();
                     IMMER_RETHROW;
                 }
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 destroy_n(dst->values(), offset);
                 IMMER_RETHROW;
             }
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             deallocate_inner(dst, n, nv + 1);
             IMMER_RETHROW;
         }
@@ -622,7 +647,8 @@ struct node
                     shift + B, std::move(v1), hash1, std::move(v2), hash2);
                 IMMER_TRY {
                     return make_inner_n(1, idx1 >> shift, merged);
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     delete_deep_shift(merged, shift + B);
                     IMMER_RETHROW;
                 }

--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -230,11 +230,11 @@ struct node
         if (embed_relaxed) {
             mr = reinterpret_cast<unsigned char*>(mp) + sizeof_inner_n(n);
         } else {
-            try {
+            IMMER_TRY {
                 mr = heap::allocate(sizeof_relaxed_n(n), norefs_tag{});
-            } catch (...) {
+            } IMMER_CATCH (...) {
                 heap::deallocate(sizeof_inner_r_n(n), mp);
-                throw;
+                IMMER_RETHROW;
             }
         }
         auto p                       = new (mp) node_t;
@@ -271,11 +271,11 @@ struct node
         if (embed_relaxed) {
             mr = reinterpret_cast<unsigned char*>(mp) + max_sizeof_inner;
         } else {
-            try {
+            IMMER_TRY {
                 mr = heap::allocate(max_sizeof_relaxed, norefs_tag{});
-            } catch (...) {
+            } IMMER_CATCH (...) {
                 heap::deallocate(max_sizeof_inner_r, mp);
-                throw;
+                IMMER_RETHROW;
             }
         }
         auto p   = new (mp) node_t;
@@ -443,11 +443,11 @@ struct node
     {
         assert(n >= 1);
         auto p = make_leaf_n(n);
-        try {
+        IMMER_TRY {
             new (p->leaf()) T{std::forward<U>(x)};
-        } catch (...) {
+        } IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(n), p);
-            throw;
+            IMMER_RETHROW;
         }
         return p;
     }
@@ -456,11 +456,11 @@ struct node
     static node_t* make_leaf_e(edit_t e, U&& x)
     {
         auto p = make_leaf_e(e);
-        try {
+        IMMER_TRY {
             new (p->leaf()) T{std::forward<U>(x)};
-        } catch (...) {
+        } IMMER_CATCH (...) {
             heap::deallocate(node_t::max_sizeof_leaf, p);
-            throw;
+            IMMER_RETHROW;
         }
         return p;
     }
@@ -472,11 +472,11 @@ struct node
             return node;
         else {
             auto n = node_t::make_inner_n(1);
-            try {
+            IMMER_TRY {
                 n->inner()[0] = make_path(shift - B, node);
-            } catch (...) {
+            } IMMER_CATCH (...) {
                 heap::deallocate(node_t::sizeof_inner_n(1), n);
-                throw;
+                IMMER_RETHROW;
             }
             return n;
         }
@@ -489,11 +489,11 @@ struct node
             return node;
         else {
             auto n = node_t::make_inner_e(e);
-            try {
+            IMMER_TRY {
                 n->inner()[0] = make_path_e(e, shift - B, node);
-            } catch (...) {
+            } IMMER_CATCH (...) {
                 heap::deallocate(node_t::max_sizeof_inner, n);
-                throw;
+                IMMER_RETHROW;
             }
             return n;
         }
@@ -590,11 +590,11 @@ struct node
     {
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(n);
-        try {
+        IMMER_TRY {
             std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
-        } catch (...) {
+        } IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(n), dst);
-            throw;
+            IMMER_RETHROW;
         }
         return dst;
     }
@@ -603,11 +603,11 @@ struct node
     {
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
-        try {
+        IMMER_TRY {
             std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
-        } catch (...) {
+        } IMMER_CATCH (...) {
             heap::deallocate(node_t::max_sizeof_leaf, dst);
-            throw;
+            IMMER_RETHROW;
         }
         return dst;
     }
@@ -617,11 +617,11 @@ struct node
         assert(allocn >= n);
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(allocn);
-        try {
+        IMMER_TRY {
             std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
-        } catch (...) {
+        } IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(allocn), dst);
-            throw;
+            IMMER_RETHROW;
         }
         return dst;
     }
@@ -631,20 +631,20 @@ struct node
         IMMER_ASSERT_TAGGED(src1->kind() == kind_t::leaf);
         IMMER_ASSERT_TAGGED(src2->kind() == kind_t::leaf);
         auto dst = make_leaf_n(n1 + n2);
-        try {
+        IMMER_TRY {
             std::uninitialized_copy(
                 src1->leaf(), src1->leaf() + n1, dst->leaf());
-        } catch (...) {
+        } IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(n1 + n2), dst);
-            throw;
+            IMMER_RETHROW;
         }
-        try {
+        IMMER_TRY {
             std::uninitialized_copy(
                 src2->leaf(), src2->leaf() + n2, dst->leaf() + n1);
-        } catch (...) {
+        } IMMER_CATCH (...) {
             destroy_n(dst->leaf(), n1);
             heap::deallocate(node_t::sizeof_leaf_n(n1 + n2), dst);
-            throw;
+            IMMER_RETHROW;
         }
         return dst;
     }
@@ -655,20 +655,20 @@ struct node
         IMMER_ASSERT_TAGGED(src1->kind() == kind_t::leaf);
         IMMER_ASSERT_TAGGED(src2->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
-        try {
+        IMMER_TRY {
             std::uninitialized_copy(
                 src1->leaf(), src1->leaf() + n1, dst->leaf());
-        } catch (...) {
+        } IMMER_CATCH (...) {
             heap::deallocate(max_sizeof_leaf, dst);
-            throw;
+            IMMER_RETHROW;
         }
-        try {
+        IMMER_TRY {
             std::uninitialized_copy(
                 src2->leaf(), src2->leaf() + n2, dst->leaf() + n1);
-        } catch (...) {
+        } IMMER_CATCH (...) {
             destroy_n(dst->leaf(), n1);
             heap::deallocate(max_sizeof_leaf, dst);
-            throw;
+            IMMER_RETHROW;
         }
         return dst;
     }
@@ -677,12 +677,12 @@ struct node
     {
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
-        try {
+        IMMER_TRY {
             std::uninitialized_copy(
                 src->leaf() + idx, src->leaf() + last, dst->leaf());
-        } catch (...) {
+        } IMMER_CATCH (...) {
             heap::deallocate(max_sizeof_leaf, dst);
-            throw;
+            IMMER_RETHROW;
         }
         return dst;
     }
@@ -691,12 +691,12 @@ struct node
     {
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(last - idx);
-        try {
+        IMMER_TRY {
             std::uninitialized_copy(
                 src->leaf() + idx, src->leaf() + last, dst->leaf());
-        } catch (...) {
+        } IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(last - idx), dst);
-            throw;
+            IMMER_RETHROW;
         }
         return dst;
     }
@@ -705,12 +705,12 @@ struct node
     static node_t* copy_leaf_emplace(node_t* src, count_t n, U&& x)
     {
         auto dst = copy_leaf_n(n + 1, src, n);
-        try {
+        IMMER_TRY {
             new (dst->leaf() + n) T{std::forward<U>(x)};
-        } catch (...) {
+        } IMMER_CATCH (...) {
             destroy_n(dst->leaf(), n);
             heap::deallocate(node_t::sizeof_leaf_n(n + 1), dst);
-            throw;
+            IMMER_RETHROW;
         }
         return dst;
     }

--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -232,7 +232,8 @@ struct node
         } else {
             IMMER_TRY {
                 mr = heap::allocate(sizeof_relaxed_n(n), norefs_tag{});
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 heap::deallocate(sizeof_inner_r_n(n), mp);
                 IMMER_RETHROW;
             }
@@ -273,7 +274,8 @@ struct node
         } else {
             IMMER_TRY {
                 mr = heap::allocate(max_sizeof_relaxed, norefs_tag{});
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 heap::deallocate(max_sizeof_inner_r, mp);
                 IMMER_RETHROW;
             }
@@ -445,7 +447,8 @@ struct node
         auto p = make_leaf_n(n);
         IMMER_TRY {
             new (p->leaf()) T{std::forward<U>(x)};
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(n), p);
             IMMER_RETHROW;
         }
@@ -458,7 +461,8 @@ struct node
         auto p = make_leaf_e(e);
         IMMER_TRY {
             new (p->leaf()) T{std::forward<U>(x)};
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             heap::deallocate(node_t::max_sizeof_leaf, p);
             IMMER_RETHROW;
         }
@@ -474,7 +478,8 @@ struct node
             auto n = node_t::make_inner_n(1);
             IMMER_TRY {
                 n->inner()[0] = make_path(shift - B, node);
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 heap::deallocate(node_t::sizeof_inner_n(1), n);
                 IMMER_RETHROW;
             }
@@ -491,7 +496,8 @@ struct node
             auto n = node_t::make_inner_e(e);
             IMMER_TRY {
                 n->inner()[0] = make_path_e(e, shift - B, node);
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 heap::deallocate(node_t::max_sizeof_inner, n);
                 IMMER_RETHROW;
             }
@@ -592,7 +598,8 @@ struct node
         auto dst = make_leaf_n(n);
         IMMER_TRY {
             std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(n), dst);
             IMMER_RETHROW;
         }
@@ -605,7 +612,8 @@ struct node
         auto dst = make_leaf_e(e);
         IMMER_TRY {
             std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             heap::deallocate(node_t::max_sizeof_leaf, dst);
             IMMER_RETHROW;
         }
@@ -619,7 +627,8 @@ struct node
         auto dst = make_leaf_n(allocn);
         IMMER_TRY {
             std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(allocn), dst);
             IMMER_RETHROW;
         }
@@ -634,14 +643,16 @@ struct node
         IMMER_TRY {
             std::uninitialized_copy(
                 src1->leaf(), src1->leaf() + n1, dst->leaf());
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(n1 + n2), dst);
             IMMER_RETHROW;
         }
         IMMER_TRY {
             std::uninitialized_copy(
                 src2->leaf(), src2->leaf() + n2, dst->leaf() + n1);
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             destroy_n(dst->leaf(), n1);
             heap::deallocate(node_t::sizeof_leaf_n(n1 + n2), dst);
             IMMER_RETHROW;
@@ -658,14 +669,16 @@ struct node
         IMMER_TRY {
             std::uninitialized_copy(
                 src1->leaf(), src1->leaf() + n1, dst->leaf());
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             heap::deallocate(max_sizeof_leaf, dst);
             IMMER_RETHROW;
         }
         IMMER_TRY {
             std::uninitialized_copy(
                 src2->leaf(), src2->leaf() + n2, dst->leaf() + n1);
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             destroy_n(dst->leaf(), n1);
             heap::deallocate(max_sizeof_leaf, dst);
             IMMER_RETHROW;
@@ -680,7 +693,8 @@ struct node
         IMMER_TRY {
             std::uninitialized_copy(
                 src->leaf() + idx, src->leaf() + last, dst->leaf());
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             heap::deallocate(max_sizeof_leaf, dst);
             IMMER_RETHROW;
         }
@@ -694,7 +708,8 @@ struct node
         IMMER_TRY {
             std::uninitialized_copy(
                 src->leaf() + idx, src->leaf() + last, dst->leaf());
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(last - idx), dst);
             IMMER_RETHROW;
         }
@@ -707,7 +722,8 @@ struct node
         auto dst = copy_leaf_n(n + 1, src, n);
         IMMER_TRY {
             new (dst->leaf() + n) T{std::forward<U>(x)};
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             destroy_n(dst->leaf(), n);
             heap::deallocate(node_t::sizeof_leaf_n(n + 1), dst);
             IMMER_RETHROW;

--- a/immer/detail/rbts/operations.hpp
+++ b/immer/detail/rbts/operations.hpp
@@ -472,7 +472,8 @@ struct update_visitor : visitor_base<update_visitor<NodeT>>
             node->inner()[offset]->dec_unsafe();
             node->inner()[offset] = child;
             return node;
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             node_t::delete_inner_r(node, count);
             IMMER_RETHROW;
         }
@@ -490,7 +491,8 @@ struct update_visitor : visitor_base<update_visitor<NodeT>>
             node->inner()[offset]->dec_unsafe();
             node->inner()[offset] = child;
             return node;
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             node_t::delete_inner(node, count);
             IMMER_RETHROW;
         }
@@ -505,7 +507,8 @@ struct update_visitor : visitor_base<update_visitor<NodeT>>
             node->leaf()[offset] =
                 std::forward<Fn>(fn)(std::move(node->leaf()[offset]));
             return node;
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             node_t::delete_leaf(node, pos.count());
             IMMER_RETHROW;
         }
@@ -605,7 +608,8 @@ struct get_mut_visitor : visitor_base<get_mut_visitor<NodeT>>
                 pos.visit(dec_visitor{});
                 *location = new_node;
                 return res;
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 dec_relaxed(new_node, pos.shift());
                 IMMER_RETHROW;
             }
@@ -635,7 +639,8 @@ struct get_mut_visitor : visitor_base<get_mut_visitor<NodeT>>
                 pos.visit(dec_visitor{});
                 *location = new_node;
                 return res;
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 dec_regular(new_node, pos.shift(), pos.size());
                 IMMER_RETHROW;
             }
@@ -719,7 +724,8 @@ struct push_tail_mut_visitor
                 if (Mutating)
                     pos.visit(dec_visitor{});
                 return new_node;
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 auto shift = pos.shift();
                 auto size  = new_idx == idx ? children + ts : ts;
                 if (shift > BL) {
@@ -757,7 +763,8 @@ struct push_tail_mut_visitor
                 if (Mutating)
                     pos.visit(dec_visitor{});
                 return new_parent;
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 node_t::delete_inner_e(new_parent);
                 IMMER_RETHROW;
             }
@@ -811,7 +818,8 @@ struct push_tail_visitor : visitor_base<push_tail_visitor<NodeT>>
             new_relaxed->d.count          = count;
             assert(new_relaxed->d.sizes[new_idx]);
             return new_parent;
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             auto shift = pos.shift();
             auto size  = new_idx == idx ? children + ts : ts;
             if (shift > BL) {
@@ -835,7 +843,8 @@ struct push_tail_visitor : visitor_base<push_tail_visitor<NodeT>>
                 idx == new_idx ? pos.last_oh(this_t{}, idx, tail)
                                /* otherwise */
                                : node_t::make_path(pos.shift() - B, tail);
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             node_t::delete_inner(new_parent, count);
             IMMER_RETHROW;
         }
@@ -964,7 +973,8 @@ struct slice_right_mut_visitor
                         return std::make_tuple(pos.shift(), newn, ts, tail);
                     }
                 }
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 assert(!mutate);
                 assert(!next || pos.shift() > BL);
                 if (next)
@@ -1032,7 +1042,8 @@ struct slice_right_mut_visitor
                         return std::make_tuple(pos.shift(), newn, ts, tail);
                     }
                 }
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 assert(!mutate);
                 assert(!next || pos.shift() > BL);
                 assert(tail);
@@ -1113,7 +1124,8 @@ struct slice_right_visitor : visitor_base<slice_right_visitor<NodeT, Collapse>>
                     auto newn = node_t::copy_inner_r(pos.node(), idx);
                     return std::make_tuple(pos.shift(), newn, ts, tail);
                 }
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 assert(!next || pos.shift() > BL);
                 if (next)
                     dec_inner(next,
@@ -1153,7 +1165,8 @@ struct slice_right_visitor : visitor_base<slice_right_visitor<NodeT, Collapse>>
                     auto newn = node_t::copy_inner_n(idx, pos.node(), idx);
                     return std::make_tuple(pos.shift(), newn, ts, tail);
                 }
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 assert(!next || pos.shift() > BL);
                 assert(tail);
                 if (next)
@@ -1277,7 +1290,8 @@ struct slice_left_mut_visitor
                         pos.visit(dec_visitor{});
                 }
                 return std::make_tuple(pos.shift(), newn);
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 if (!mutate)
                     node_t::delete_inner_r_e(newn);
                 IMMER_RETHROW;
@@ -1343,7 +1357,8 @@ struct slice_left_mut_visitor
                         pos.visit(dec_visitor{});
                 }
                 return std::make_tuple(pos.shift(), newn);
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 if (!mutate)
                     node_t::delete_inner_r_e(newn);
                 else {
@@ -1429,7 +1444,8 @@ struct slice_left_visitor : visitor_base<slice_left_visitor<NodeT, Collapse>>
                                         newn->inner() + 1);
                 node_t::inc_nodes(newn->inner() + 1, newr->d.count - 1);
                 return std::make_tuple(pos.shift(), newn);
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 node_t::delete_inner_r(newn, newc);
                 IMMER_RETHROW;
             }
@@ -1515,7 +1531,8 @@ struct concat_center_pos
                 std::copy(nodes_, nodes_ + count_, result->inner());
                 std::copy(sizes_, sizes_ + count_, r->d.sizes);
                 return {result, shift_, r};
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 each_sub(dec_visitor{});
                 IMMER_RETHROW;
             }
@@ -1790,7 +1807,8 @@ struct concat_rebalance_plan
             rpos.each_right_sub(visitor_t{}, merger);
             cpos.each_sub(dec_visitor{});
             return merger.finish();
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             merger.abort();
             IMMER_RETHROW;
         }
@@ -1805,7 +1823,8 @@ concat_center_pos<Node> concat_rebalance(LPos&& lpos, CPos&& cpos, RPos&& rpos)
     plan.shuffle(cpos.shift());
     IMMER_TRY {
         return plan.merge(lpos, cpos, rpos);
-    } IMMER_CATCH (...) {
+    }
+    IMMER_CATCH (...) {
         cpos.each_sub(dec_visitor{});
         IMMER_RETHROW;
     }
@@ -2240,7 +2259,8 @@ struct concat_rebalance_plan_mut : concat_rebalance_plan<B, BL>
                 merger.set_candidate(er, rnode);
             rpos.each_right_sub(visitor_t{}, merger, er);
             return merger.finish();
-        } IMMER_CATCH (...) {
+        }
+        IMMER_CATCH (...) {
             merger.abort();
             IMMER_RETHROW;
         }

--- a/immer/detail/rbts/rbtree.hpp
+++ b/immer/detail/rbts/rbtree.hpp
@@ -273,7 +273,8 @@ struct rbtree
                         root                 = new_root;
                         tail                 = new_tail;
                         shift += B;
-                    } IMMER_CATCH (...) {
+                    }
+                    IMMER_CATCH (...) {
                         node_t::delete_inner_e(new_root);
                         IMMER_RETHROW;
                     }
@@ -290,7 +291,8 @@ struct rbtree
                     root = new_root;
                     tail = new_tail;
                 }
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 node_t::delete_leaf(new_tail, 1);
                 IMMER_RETHROW;
             }
@@ -318,7 +320,8 @@ struct rbtree
                         root->inc();
                         tail->inc();
                         return {size + 1, shift + B, new_root, new_tail};
-                    } IMMER_CATCH (...) {
+                    }
+                    IMMER_CATCH (...) {
                         node_t::delete_inner(new_root, 2);
                         IMMER_RETHROW;
                     }
@@ -333,7 +336,8 @@ struct rbtree
                     tail->inc();
                     return {size + 1, shift, new_root, new_tail};
                 }
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 node_t::delete_leaf(new_tail, 1);
                 IMMER_RETHROW;
             }

--- a/immer/detail/rbts/rbtree.hpp
+++ b/immer/detail/rbts/rbtree.hpp
@@ -15,6 +15,7 @@
 #include <immer/detail/type_traits.hpp>
 
 #include <cassert>
+#include <exception>
 #include <memory>
 #include <numeric>
 
@@ -262,19 +263,19 @@ struct rbtree
             new (&tail->leaf()[ts]) T{std::move(value)};
         } else {
             auto new_tail = node_t::make_leaf_e(e, std::move(value));
-            try {
+            IMMER_TRY {
                 if (tail_off == size_t{branches<B>} << shift) {
                     auto new_root = node_t::make_inner_e(e);
-                    try {
+                    IMMER_TRY {
                         auto path = node_t::make_path_e(e, shift, tail);
                         new_root->inner()[0] = root;
                         new_root->inner()[1] = path;
                         root                 = new_root;
                         tail                 = new_tail;
                         shift += B;
-                    } catch (...) {
+                    } IMMER_CATCH (...) {
                         node_t::delete_inner_e(new_root);
-                        throw;
+                        IMMER_RETHROW;
                     }
                 } else if (tail_off) {
                     auto new_root =
@@ -289,9 +290,9 @@ struct rbtree
                     root = new_root;
                     tail = new_tail;
                 }
-            } catch (...) {
+            } IMMER_CATCH (...) {
                 node_t::delete_leaf(new_tail, 1);
-                throw;
+                IMMER_RETHROW;
             }
         }
         ++size;
@@ -307,19 +308,19 @@ struct rbtree
             return {size + 1, shift, root->inc(), new_tail};
         } else {
             auto new_tail = node_t::make_leaf_n(1, std::move(value));
-            try {
+            IMMER_TRY {
                 if (tail_off == size_t{branches<B>} << shift) {
                     auto new_root = node_t::make_inner_n(2);
-                    try {
+                    IMMER_TRY {
                         auto path            = node_t::make_path(shift, tail);
                         new_root->inner()[0] = root;
                         new_root->inner()[1] = path;
                         root->inc();
                         tail->inc();
                         return {size + 1, shift + B, new_root, new_tail};
-                    } catch (...) {
+                    } IMMER_CATCH (...) {
                         node_t::delete_inner(new_root, 2);
-                        throw;
+                        IMMER_RETHROW;
                     }
                 } else if (tail_off) {
                     auto new_root =
@@ -332,9 +333,9 @@ struct rbtree
                     tail->inc();
                     return {size + 1, shift, new_root, new_tail};
                 }
-            } catch (...) {
+            } IMMER_CATCH (...) {
                 node_t::delete_leaf(new_tail, 1);
-                throw;
+                IMMER_RETHROW;
             }
         }
     }
@@ -364,7 +365,7 @@ struct rbtree
     const T& get_check(size_t index) const
     {
         if (index >= size)
-            throw std::out_of_range{"index out of range"};
+            IMMER_THROW(std::out_of_range{"index out of range"});
         return descend(get_visitor<T>(), index);
     }
 

--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -329,7 +329,8 @@ struct rrbtree
                     assert(size);
                     assert(tail_size);
                     new_root->relaxed()->d.count = 2u;
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     node_t::delete_inner_r(new_root, 2);
                     IMMER_RETHROW;
                 }
@@ -341,7 +342,8 @@ struct rrbtree
                 auto new_path        = node_t::make_path(shift, tail);
                 new_root->inner()[0] = root->inc();
                 new_root->inner()[1] = new_path;
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 node_t::delete_inner(new_root, 2);
                 IMMER_RETHROW;
             }
@@ -377,7 +379,8 @@ struct rrbtree
                     new_root->relaxed()->d.count = 2u;
                     root                         = new_root;
                     shift += B;
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     node_t::delete_inner_r_e(new_root);
                     IMMER_RETHROW;
                 }
@@ -390,7 +393,8 @@ struct rrbtree
                 new_root->inner()[1] = new_path;
                 root                 = new_root;
                 shift += B;
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 node_t::delete_inner_e(new_root);
                 IMMER_RETHROW;
             }
@@ -428,7 +432,8 @@ struct rrbtree
             IMMER_TRY {
                 push_tail_mut(e, tail_off, tail, ts);
                 tail = new_tail;
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 node_t::delete_leaf(new_tail, 1u);
                 IMMER_RETHROW;
             }
@@ -452,7 +457,8 @@ struct rrbtree
                     push_tail(root, shift, tail_off, tail, size - tail_off);
                 tail->inc();
                 return {size + 1, get<0>(new_root), get<1>(new_root), new_tail};
-            } IMMER_CATCH (...) {
+            }
+            IMMER_CATCH (...) {
                 node_t::delete_leaf(new_tail, 1u);
                 IMMER_RETHROW;
             }
@@ -708,11 +714,13 @@ struct rrbtree
                                 get<0>(new_root),
                                 get<1>(new_root),
                                 new_tail};
-                    } IMMER_CATCH (...) {
+                    }
+                    IMMER_CATCH (...) {
                         node_t::delete_leaf(new_tail, r.size - remaining);
                         IMMER_RETHROW;
                     }
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     node_t::delete_leaf(add_tail, branches<BL>);
                     IMMER_RETHROW;
                 }
@@ -788,11 +796,13 @@ struct rrbtree
                         l.tail = new_tail;
                         l.size += r.size;
                         return;
-                    } IMMER_CATCH (...) {
+                    }
+                    IMMER_CATCH (...) {
                         node_t::delete_leaf(new_tail, r.size - remaining);
                         IMMER_RETHROW;
                     }
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     destroy_n(r.tail->leaf() + tail_size, remaining);
                     IMMER_RETHROW;
                 }
@@ -931,11 +941,13 @@ struct rrbtree
                              get<1>(new_root),
                              new_tail};
                         return;
-                    } IMMER_CATCH (...) {
+                    }
+                    IMMER_CATCH (...) {
                         node_t::delete_leaf(new_tail, r.size - remaining);
                         IMMER_RETHROW;
                     }
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     node_t::delete_leaf(add_tail, branches<BL>);
                     IMMER_RETHROW;
                 }
@@ -1062,11 +1074,13 @@ struct rrbtree
                         l.tail = new_tail;
                         l.size += r.size;
                         return;
-                    } IMMER_CATCH (...) {
+                    }
+                    IMMER_CATCH (...) {
                         node_t::delete_leaf(new_tail, r.size - remaining);
                         IMMER_RETHROW;
                     }
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     destroy_n(r.tail->leaf() + tail_size, remaining);
                     IMMER_RETHROW;
                 }
@@ -1204,11 +1218,13 @@ struct rrbtree
                              get<1>(new_root),
                              new_tail};
                         return;
-                    } IMMER_CATCH (...) {
+                    }
+                    IMMER_CATCH (...) {
                         node_t::delete_leaf(new_tail, r.size - remaining);
                         IMMER_RETHROW;
                     }
-                } IMMER_CATCH (...) {
+                }
+                IMMER_CATCH (...) {
                     node_t::delete_leaf(add_tail, branches<BL>);
                     IMMER_RETHROW;
                 }

--- a/immer/detail/util.hpp
+++ b/immer/detail/util.hpp
@@ -65,11 +65,11 @@ template <typename Heap, typename T, typename... Args>
 T* make(Args&&... args)
 {
     auto ptr = Heap::allocate(sizeof(T));
-    try {
+    IMMER_TRY {
         return new (ptr) T{std::forward<Args>(args)...};
-    } catch (...) {
+    } IMMER_CATCH (...) {
         Heap::deallocate(sizeof(T), ptr);
-        throw;
+        IMMER_RETHROW;
     }
 }
 
@@ -245,17 +245,17 @@ template <typename SourceIter,
 SinkIter uninitialized_copy(SourceIter first, Sent last, SinkIter d_first)
 {
     auto current = d_first;
-    try {
+    IMMER_TRY {
         while (first != last) {
             *current++ = *first;
             ++first;
         }
-    } catch (...) {
+    } IMMER_CATCH (...) {
         using Value = typename std::iterator_traits<SinkIter>::value_type;
         for (; d_first != current; ++d_first) {
             d_first->~Value();
         }
-        throw;
+        IMMER_RETHROW;
     }
     return current;
 }

--- a/immer/detail/util.hpp
+++ b/immer/detail/util.hpp
@@ -67,7 +67,8 @@ T* make(Args&&... args)
     auto ptr = Heap::allocate(sizeof(T));
     IMMER_TRY {
         return new (ptr) T{std::forward<Args>(args)...};
-    } IMMER_CATCH (...) {
+    }
+    IMMER_CATCH (...) {
         Heap::deallocate(sizeof(T), ptr);
         IMMER_RETHROW;
     }
@@ -250,7 +251,8 @@ SinkIter uninitialized_copy(SourceIter first, Sent last, SinkIter d_first)
             *current++ = *first;
             ++first;
         }
-    } IMMER_CATCH (...) {
+    }
+    IMMER_CATCH (...) {
         using Value = typename std::iterator_traits<SinkIter>::value_type;
         for (; d_first != current; ++d_first) {
             d_first->~Value();

--- a/immer/heap/gc_heap.hpp
+++ b/immer/heap/gc_heap.hpp
@@ -17,7 +17,9 @@
 #error "Using garbage collection requires libgc"
 #endif
 
+#include <cassert>
 #include <cstdlib>
+#include <exception>
 #include <memory>
 
 namespace immer {
@@ -105,7 +107,7 @@ public:
         IMMER_GC_INIT_GUARD_;
         auto p = GC_malloc(n);
         if (IMMER_UNLIKELY(!p))
-            throw std::bad_alloc{};
+            IMMER_THROW(std::bad_alloc{});
         return p;
     }
 
@@ -114,7 +116,7 @@ public:
         IMMER_GC_INIT_GUARD_;
         auto p = GC_malloc_atomic(n);
         if (IMMER_UNLIKELY(!p))
-            throw std::bad_alloc{};
+            IMMER_THROW(std::bad_alloc{});
         return p;
     }
 

--- a/immer/heap/malloc_heap.hpp
+++ b/immer/heap/malloc_heap.hpp
@@ -10,7 +10,9 @@
 
 #include <immer/config.hpp>
 
+#include <cassert>
 #include <cstdlib>
+#include <exception>
 #include <memory>
 
 namespace immer {
@@ -29,7 +31,7 @@ struct malloc_heap
     {
         auto p = std::malloc(size);
         if (IMMER_UNLIKELY(!p))
-            throw std::bad_alloc{};
+            IMMER_THROW(std::bad_alloc{});
         return p;
     }
 

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -12,6 +12,8 @@
 #include <immer/detail/hamts/champ_iterator.hpp>
 #include <immer/memory_policy.hpp>
 
+#include <cassert>
+#include <exception>
 #include <functional>
 
 namespace immer {
@@ -103,7 +105,7 @@ class map
     {
         const T& operator()() const
         {
-            throw std::out_of_range{"key not found"};
+            IMMER_THROW(std::out_of_range{"key not found"});
         }
     };
 

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -120,8 +120,10 @@ TEST_CASE("at")
     CHECK(v.at(0) == 0);
     CHECK(v.at(42) == 42);
     CHECK(v.at(665) == 665);
+#ifndef IMMER_NO_EXCEPTIONS
     CHECK_THROWS_AS(v.at(666), std::out_of_range&);
     CHECK_THROWS_AS(v.at(1234), std::out_of_range&);
+#endif
 }
 
 TEST_CASE("find")

--- a/test/vector/generic.ipp
+++ b/test/vector/generic.ipp
@@ -112,8 +112,10 @@ TEST_CASE("at")
     auto v = VECTOR_T<unsigned>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     CHECK(v.at(0) == 0);
     CHECK(v.at(5) == 5);
+#ifndef IMMER_NO_EXCEPTIONS
     CHECK_THROWS_AS(v.at(10), const std::out_of_range&);
     CHECK_THROWS_AS(v.at(11), const std::out_of_range&);
+#endif
 }
 
 TEST_CASE("push back one element")


### PR DESCRIPTION
Replaces all try/catch/throw keyword usage with a set of macros that are
appropriately defined in config.hpp based on the status of the
`cxx_exceptions` compiler feature.

Reported in issue #160.