### PR TITLE
Added missing <immer/config.hpp> and <cstddef> includes

### DIFF
--- a/immer/array.hpp
+++ b/immer/array.hpp
@@ -11,6 +11,8 @@
 #include <immer/detail/arrays/with_capacity.hpp>
 #include <immer/memory_policy.hpp>
 
+#include <cstddef>
+
 namespace immer {
 
 template <typename T, typename MemoryPolicy>

--- a/immer/array_transient.hpp
+++ b/immer/array_transient.hpp
@@ -11,6 +11,8 @@
 #include <immer/detail/arrays/with_capacity.hpp>
 #include <immer/memory_policy.hpp>
 
+#include <cstddef>
+
 namespace immer {
 
 template <typename T, typename MemoryPolicy>

--- a/immer/box.hpp
+++ b/immer/box.hpp
@@ -11,6 +11,8 @@
 #include <immer/detail/util.hpp>
 #include <immer/memory_policy.hpp>
 
+#include <cstddef>
+
 namespace immer {
 
 namespace detail {

--- a/immer/detail/arrays/no_capacity.hpp
+++ b/immer/detail/arrays/no_capacity.hpp
@@ -9,9 +9,11 @@
 #pragma once
 
 #include <immer/algorithm.hpp>
+#include <immer/config.hpp>
 #include <immer/detail/arrays/node.hpp>
 
 #include <cassert>
+#include <cstddef>
 #include <exception>
 
 namespace immer {

--- a/immer/detail/arrays/node.hpp
+++ b/immer/detail/arrays/node.hpp
@@ -8,10 +8,12 @@
 
 #pragma once
 
+#include <immer/config.hpp>
 #include <immer/detail/combine_standard_layout.hpp>
 #include <immer/detail/type_traits.hpp>
 #include <immer/detail/util.hpp>
 
+#include <cstddef>
 #include <limits>
 
 namespace immer {

--- a/immer/detail/arrays/with_capacity.hpp
+++ b/immer/detail/arrays/with_capacity.hpp
@@ -8,9 +8,11 @@
 
 #pragma once
 
+#include <immer/config.hpp>
 #include <immer/detail/arrays/no_capacity.hpp>
 
 #include <cassert>
+#include <cstddef>
 #include <exception>
 
 namespace immer {

--- a/immer/detail/combine_standard_layout.hpp
+++ b/immer/detail/combine_standard_layout.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <type_traits>
 
 #if defined(__GNUC__) && __GNUC__ == 7 && __GNUC_MINOR__ == 1

--- a/immer/detail/hamts/bits.hpp
+++ b/immer/detail/hamts/bits.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 #if defined(_MSC_VER)

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -8,11 +8,13 @@
 
 #pragma once
 
+#include <immer/config.hpp>
 #include <immer/detail/combine_standard_layout.hpp>
 #include <immer/detail/hamts/bits.hpp>
 #include <immer/detail/util.hpp>
 
 #include <cassert>
+#include <cstddef>
 
 namespace immer {
 namespace detail {

--- a/immer/detail/rbts/bits.hpp
+++ b/immer/detail/rbts/bits.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 namespace immer {

--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <immer/config.hpp>
 #include <immer/detail/combine_standard_layout.hpp>
 #include <immer/detail/rbts/bits.hpp>
 #include <immer/detail/util.hpp>

--- a/immer/detail/rbts/rbtree.hpp
+++ b/immer/detail/rbts/rbtree.hpp
@@ -8,10 +8,10 @@
 
 #pragma once
 
+#include <immer/config.hpp>
 #include <immer/detail/rbts/node.hpp>
 #include <immer/detail/rbts/operations.hpp>
 #include <immer/detail/rbts/position.hpp>
-
 #include <immer/detail/type_traits.hpp>
 
 #include <cassert>

--- a/immer/experimental/detail/dvektor_impl.hpp
+++ b/immer/experimental/detail/dvektor_impl.hpp
@@ -17,6 +17,7 @@
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
 #include <cassert>
+#include <cstddef>
 #include <limits>
 
 namespace immer {

--- a/immer/experimental/dvektor.hpp
+++ b/immer/experimental/dvektor.hpp
@@ -12,6 +12,8 @@
 
 #include <immer/memory_policy.hpp>
 
+#include <cstddef>
+
 namespace immer {
 
 template <typename T, int B = 5, typename MemoryPolicy = default_memory_policy>

--- a/immer/heap/cpp_heap.hpp
+++ b/immer/heap/cpp_heap.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 
 namespace immer {

--- a/immer/heap/free_list_heap.hpp
+++ b/immer/heap/free_list_heap.hpp
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <cstddef>
 
 namespace immer {
 

--- a/immer/heap/split_heap.hpp
+++ b/immer/heap/split_heap.hpp
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <cstddef>
 
 namespace immer {
 

--- a/immer/heap/thread_local_free_list_heap.hpp
+++ b/immer/heap/thread_local_free_list_heap.hpp
@@ -10,6 +10,8 @@
 
 #include <immer/heap/unsafe_free_list_heap.hpp>
 
+#include <cstddef>
+
 namespace immer {
 namespace detail {
 

--- a/immer/heap/unsafe_free_list_heap.hpp
+++ b/immer/heap/unsafe_free_list_heap.hpp
@@ -8,9 +8,11 @@
 
 #pragma once
 
-#include <cassert>
 #include <immer/config.hpp>
 #include <immer/heap/free_list_node.hpp>
+
+#include <cassert>
+#include <cstddef>
 
 namespace immer {
 namespace detail {

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <immer/config.hpp>
 #include <immer/detail/hamts/champ.hpp>
 #include <immer/detail/hamts/champ_iterator.hpp>
 #include <immer/memory_policy.hpp>


### PR DESCRIPTION
The former needed for the new exception macros and the latter for the
usage of std::size_t.

Minor include ordering changes too.