### PR TITLE
Change <exception> includes to <stdexcept> when using standard exceptions

### DIFF
--- a/immer/detail/arrays/no_capacity.hpp
+++ b/immer/detail/arrays/no_capacity.hpp
@@ -14,7 +14,7 @@
 
 #include <cassert>
 #include <cstddef>
-#include <exception>
+#include <stdexcept>
 
 namespace immer {
 namespace detail {

--- a/immer/detail/arrays/with_capacity.hpp
+++ b/immer/detail/arrays/with_capacity.hpp
@@ -13,7 +13,7 @@
 
 #include <cassert>
 #include <cstddef>
-#include <exception>
+#include <stdexcept>
 
 namespace immer {
 namespace detail {

--- a/immer/detail/rbts/rbtree.hpp
+++ b/immer/detail/rbts/rbtree.hpp
@@ -15,7 +15,7 @@
 #include <immer/detail/type_traits.hpp>
 
 #include <cassert>
-#include <exception>
+#include <stdexcept>
 #include <memory>
 #include <numeric>
 

--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -16,7 +16,7 @@
 #include <immer/detail/type_traits.hpp>
 
 #include <cassert>
-#include <exception>
+#include <stdexcept>
 #include <memory>
 #include <numeric>
 

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -14,7 +14,7 @@
 #include <immer/memory_policy.hpp>
 
 #include <cassert>
-#include <exception>
+#include <stdexcept>
 #include <functional>
 
 namespace immer {


### PR DESCRIPTION
Standard exceptions like `std::out_of_range` are defined in `<stdexcept>`, not in `<exception>`.
This fixes compilation issues i had with MSVC if I didn't include `<stdexcept>` before including some immer headers.
Thanks for this library btw !