### PR TITLE
Transparent Hash for Map and Sets

### DIFF
--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 #include <memory>
 #include <numeric>
+#include <limits>
 
 namespace immer {
 namespace detail {

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -114,7 +114,8 @@ class map
     {
         auto operator()(const value_t& v) { return Hash{}(v.first); }
 
-        auto operator()(const K& v) { return Hash{}(v); }
+        template<typename Key>
+        auto operator()(const Key& v) { return Hash{}(v); }
     };
 
     struct equal_key
@@ -124,7 +125,8 @@ class map
             return Equal{}(a.first, b.first);
         }
 
-        auto operator()(const value_t& a, const K& b)
+        template<typename Key>
+        auto operator()(const value_t& a, const Key& b)
         {
             return Equal{}(a.first, b);
         }
@@ -197,7 +199,8 @@ public:
      * otherwise. It won't allocate memory and its complexity is
      * *effectively* @f$ O(1) @f$.
      */
-    IMMER_NODISCARD size_type count(const K& k) const
+    template<typename Key>
+    IMMER_NODISCARD size_type count(const Key& k) const
     {
         return impl_.template get<detail::constantly<size_type, 1>,
                                   detail::constantly<size_type, 0>>(k);
@@ -209,7 +212,8 @@ public:
      * default constructed value.  It does not allocate memory and its
      * complexity is *effectively* @f$ O(1) @f$.
      */
-    IMMER_NODISCARD const T& operator[](const K& k) const
+    template<typename Key>
+    IMMER_NODISCARD const T& operator[](const Key& k) const
     {
         return impl_.template get<project_value, default_value>(k);
     }
@@ -220,7 +224,8 @@ public:
      * `std::out_of_range` error.  It does not allocate memory and its
      * complexity is *effectively* @f$ O(1) @f$.
      */
-    const T& at(const K& k) const
+    template<typename Key>
+    const T& at(const Key& k) const
     {
         return impl_.template get<project_value, error_value>(k);
     }
@@ -254,7 +259,8 @@ public:
      *
      * @endrst
      */
-    IMMER_NODISCARD const T* find(const K& k) const
+    template<typename Key>
+    IMMER_NODISCARD const T* find(const Key& k) const
     {
         return impl_.template get<project_value_ptr,
                                   detail::constantly<const T*, nullptr>>(k);

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -198,9 +198,23 @@ public:
      * Returns `1` when the key `k` is contained in the map or `0`
      * otherwise. It won't allocate memory and its complexity is
      * *effectively* @f$ O(1) @f$.
+     *
+     * This overload participates in overload resolution only if
+     * `Hash::is_transparent` is valid and denotes a type.
      */
-    template<typename Key>
+    template<typename Key, typename U = Hash, typename = typename U::is_transparent>
     IMMER_NODISCARD size_type count(const Key& k) const
+    {
+        return impl_.template get<detail::constantly<size_type, 1>,
+                                  detail::constantly<size_type, 0>>(k);
+    }
+
+    /*!
+     * Returns `1` when the key `k` is contained in the map or `0`
+     * otherwise. It won't allocate memory and its complexity is
+     * *effectively* @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD size_type count(const K& k) const
     {
         return impl_.template get<detail::constantly<size_type, 1>,
                                   detail::constantly<size_type, 0>>(k);
@@ -211,9 +225,23 @@ public:
      * `k`.  If the key is not contained in the map, it returns a
      * default constructed value.  It does not allocate memory and its
      * complexity is *effectively* @f$ O(1) @f$.
+     *
+     * This overload participates in overload resolution only if
+     * `Hash::is_transparent` is valid and denotes a type.
      */
-    template<typename Key>
+    template<typename Key, typename U = Hash, typename = typename U::is_transparent>
     IMMER_NODISCARD const T& operator[](const Key& k) const
+    {
+        return impl_.template get<project_value, default_value>(k);
+    }
+
+    /*!
+     * Returns a `const` reference to the values associated to the key
+     * `k`.  If the key is not contained in the map, it returns a
+     * default constructed value.  It does not allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD const T& operator[](const K& k) const
     {
         return impl_.template get<project_value, default_value>(k);
     }
@@ -224,8 +252,22 @@ public:
      * `std::out_of_range` error.  It does not allocate memory and its
      * complexity is *effectively* @f$ O(1) @f$.
      */
-    template<typename Key>
+    template<typename Key, typename U = Hash, typename = typename U::is_transparent>
     const T& at(const Key& k) const
+    {
+        return impl_.template get<project_value, error_value>(k);
+    }
+
+    /*!
+     * Returns a `const` reference to the values associated to the key
+     * `k`.  If the key is not contained in the map, throws an
+     * `std::out_of_range` error.  It does not allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     *
+     * This overload participates in overload resolution only if
+     * `Hash::is_transparent` is valid and denotes a type.
+     */
+    const T& at(const K& k) const
     {
         return impl_.template get<project_value, error_value>(k);
     }
@@ -259,7 +301,23 @@ public:
      *
      * @endrst
      */
-    template<typename Key>
+    IMMER_NODISCARD const T* find(const K& k) const
+    {
+        return impl_.template get<project_value_ptr,
+                                  detail::constantly<const T*, nullptr>>(k);
+    }
+
+
+    /*!
+     * Returns a pointer to the value associated with the key `k`.  If
+     * the key is not contained in the map, a `nullptr` is returned.
+     * It does not allocate memory and its complexity is *effectively*
+     * @f$ O(1) @f$.
+     *
+     * This overload participates in overload resolution only if
+     * `Hash::is_transparent` is valid and denotes a type.
+     */
+    template<typename Key, typename U = Hash, typename = typename U::is_transparent>
     IMMER_NODISCARD const T* find(const Key& k) const
     {
         return impl_.template get<project_value_ptr,

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -122,7 +122,8 @@ public:
      * otherwise. It won't allocate memory and its complexity is
      * *effectively* @f$ O(1) @f$.
      */
-    IMMER_NODISCARD size_type count(const T& value) const
+    template<typename K>
+    IMMER_NODISCARD size_type count(const K& value) const
     {
         return impl_.template get<detail::constantly<size_type, 1>,
                                   detail::constantly<size_type, 0>>(value);
@@ -134,7 +135,8 @@ public:
      * It does not allocate memory and its complexity is *effectively*
      * @f$ O(1) @f$.
      */
-    IMMER_NODISCARD const T* find(const T& value) const
+    template<typename K>
+    IMMER_NODISCARD const T* find(const K& value) const
     {
         return impl_.template get<project_value_ptr,
                                   detail::constantly<const T*, nullptr>>(value);

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -121,9 +121,23 @@ public:
      * Returns `1` when `value` is contained in the set or `0`
      * otherwise. It won't allocate memory and its complexity is
      * *effectively* @f$ O(1) @f$.
+     *
+     * This overload participates in overload resolution only if
+     * `Hash::is_transparent` is valid and denotes a type.
      */
-    template<typename K>
+    template<typename K, typename U = Hash, typename = typename U::is_transparent>
     IMMER_NODISCARD size_type count(const K& value) const
+    {
+        return impl_.template get<detail::constantly<size_type, 1>,
+                                  detail::constantly<size_type, 0>>(value);
+    }
+
+    /*!
+     * Returns `1` when `value` is contained in the set or `0`
+     * otherwise. It won't allocate memory and its complexity is
+     * *effectively* @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD size_type count(const T& value) const
     {
         return impl_.template get<detail::constantly<size_type, 1>,
                                   detail::constantly<size_type, 0>>(value);
@@ -135,7 +149,22 @@ public:
      * It does not allocate memory and its complexity is *effectively*
      * @f$ O(1) @f$.
      */
-    template<typename K>
+    IMMER_NODISCARD const T* find(const T& value) const
+    {
+        return impl_.template get<project_value_ptr,
+                                  detail::constantly<const T*, nullptr>>(value);
+    }
+
+    /*!
+     * Returns a pointer to the value if `value` is contained in the
+     * set, or nullptr otherwise.
+     * It does not allocate memory and its complexity is *effectively*
+     * @f$ O(1) @f$.
+     *
+     * This overload participates in overload resolution only if
+     * `Hash::is_transparent` is valid and denotes a type.
+     */
+    template<typename K, typename U = Hash, typename = typename U::is_transparent>
     IMMER_NODISCARD const T* find(const K& value) const
     {
         return impl_.template get<project_value_ptr,

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -289,6 +289,7 @@ struct LookupType {
 struct TransparentHash
 {
     using hash_type = std::hash<unsigned>;
+    using is_transparent = void;
 
     size_t operator()(KeyType const& k) const { return hash_type{}(k.value); }
     size_t operator()(LookupType const& k) const
@@ -301,9 +302,6 @@ bool operator==(KeyType const& k, KeyType const& l) {
     return k.value == l.value;
 }
 bool operator==(KeyType const& k, LookupType const& l) {
-    return k.value == l.value;
-}
-bool operator==(LookupType const& l, KeyType const& k) {
     return k.value == l.value;
 }
 }

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -276,6 +276,52 @@ TEST_CASE("exception safety")
 }
 
 namespace {
+struct KeyType {
+    explicit KeyType(unsigned v) : value(v) {}
+    unsigned value;
+};
+
+struct LookupType {
+    explicit LookupType(unsigned v) : value(v) {}
+    unsigned value;
+};
+
+struct TransparentHash
+{
+    using hash_type = std::hash<unsigned>;
+
+    size_t operator()(KeyType const& k) const { return hash_type{}(k.value); }
+    size_t operator()(LookupType const& k) const
+    {
+        return hash_type{}(k.value);
+    }
+};
+
+bool operator==(KeyType const& k, KeyType const& l) {
+    return k.value == l.value;
+}
+bool operator==(KeyType const& k, LookupType const& l) {
+    return k.value == l.value;
+}
+bool operator==(LookupType const& l, KeyType const& k) {
+    return k.value == l.value;
+}
+}
+
+TEST_CASE("lookup with transparent hash")
+{
+    SECTION("default")
+    {
+        auto m = MAP_T<KeyType, int, TransparentHash, std::equal_to<>>{};
+        m = m.insert({KeyType{1}, 12});
+
+        auto const& v = m.at(LookupType{1});
+        CHECK(v == 12);
+    }
+}
+
+
+namespace {
 
 class KElem
 {

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -473,6 +473,7 @@ struct LookupType {
 struct TransparentHash
 {
     using hash_type = std::hash<unsigned>;
+    using is_transparent = void;
 
     size_t operator()(KeyType const& k) const { return hash_type{}(k.value); }
     size_t operator()(LookupType const& k) const

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -390,7 +390,7 @@ TEST_CASE("exception safety")
                 ++i;
             } catch (dada_error) {}
             for (auto i : test_irange(0u, i))
-                CHECK(v.count(i) == 1);
+                CHECK(v.count({i}) == 1);
         }
         CHECK(d.happenings > 0);
         IMMER_TRACE_E(d.happenings);
@@ -408,7 +408,7 @@ TEST_CASE("exception safety")
                 ++i;
             } catch (dada_error) {}
             for (auto i : test_irange(0u, i))
-                CHECK(v.count(vals[i]) == 1);
+                CHECK(v.count({vals[i]}) == 1);
         }
         CHECK(d.happenings > 0);
         IMMER_TRACE_E(d.happenings);
@@ -427,9 +427,9 @@ TEST_CASE("exception safety")
                 ++i;
             } catch (dada_error) {}
             for (auto i : test_irange(0u, i))
-                CHECK(v.count(i) == 0);
+                CHECK(v.count({i}) == 0);
             for (auto i : test_irange(i, n))
-                CHECK(v.count(i) == 1);
+                CHECK(v.count({i}) == 1);
         }
         CHECK(d.happenings > 0);
         IMMER_TRACE_E(d.happenings);
@@ -449,9 +449,9 @@ TEST_CASE("exception safety")
                 ++i;
             } catch (dada_error) {}
             for (auto i : test_irange(0u, i))
-                CHECK(v.count(vals[i]) == 0);
+                CHECK(v.count({vals[i]}) == 0);
             for (auto i : test_irange(i, n))
-                CHECK(v.count(vals[i]) == 1);
+                CHECK(v.count({vals[i]}) == 1);
         }
         CHECK(d.happenings > 0);
         IMMER_TRACE_E(d.happenings);


### PR DESCRIPTION
I opened this [issue](https://github.com/arximboldi/immer/issues/183) but then I though I could give it a try myself.

What I did was the following: whenever you refer to `K` as key type I replaced it with a template parameter. This allows you to put in any type that is supported by the hash object. I followed the c++20 convention for `std::unordered_map` such that those new functions only participate in overload resolution if `Hash::is_transparent` is a valid type.

This is just a proof of concept. There are more things one could consider:
- add template overloads to other member functions like `erase`.
- write more tests for other functions as well 🙈 

I added `immer/detail/rbts/rrbtree.hpp` because newer compilers no longer include `<limits>` as part of other stl headers.