### PR TITLE
slightly tweak implementation of empty collection nodes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # needed for fetchGit in default.nix
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v14.1
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v10
         with:
           name: arximboldi
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
@@ -23,11 +23,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v14.1
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v10
         with:
           name: arximboldi
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
@@ -35,12 +35,12 @@ jobs:
       - run: nix-shell --run "cd build && cmake .."
       - run: nix-shell --run "cd build && make docs"
       - uses: shimataro/ssh-key-action@v2
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && github.repository_owner == 'arximboldi'
         with:
           key: ${{ secrets.SINUSOIDES_SSH_KEY }}
           known_hosts: ${{ secrets.SINUSOIDES_KNOWN_HOSTS }}
       - run: nix-shell --run "cd build && make upload-docs"
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && github.repository_owner == 'arximboldi'
 
   check:
     strategy:
@@ -87,11 +87,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v14.1
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v10
         with:
           name: arximboldi
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
@@ -113,11 +113,11 @@ jobs:
           "
       - run: nix-shell --argstr toolchain ${{ matrix.toolchain }} --run "cd build && make check -j`nproc`"
       - run: nix-shell --argstr toolchain ${{ matrix.toolchain }} --run "bash <(curl -s https://codecov.io/bash)"
-        if: ${{ contains(matrix.opts, 'coverage') }}
+        if: contains(matrix.opts, 'coverage')
       - uses: shimataro/ssh-key-action@v2
-        if: ${{ contains(matrix.opts, 'benchmark') }}
+        if: contains(matrix.opts, 'benchmark') && github.repository_owner == 'arximboldi'
         with:
           key: ${{ secrets.SINUSOIDES_SSH_KEY }}
           known_hosts: ${{ secrets.SINUSOIDES_KNOWN_HOSTS }}
       - run: nix-shell --run "cd build && make upload-benchmark-reports"
-        if: ${{ contains(matrix.opts, 'benchmark') }}
+        if: contains(matrix.opts, 'benchmark') && github.repository_owner == 'arximboldi'

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ __pycache__
 tools/clojure/.lein*
 
 *.pyc
+
+/result*

--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,29 @@
-with import <nixpkgs> {};
+{ pkgs ? import <nixpkgs> {} }:
 
+with pkgs;
+
+let
+  inherit (import (pkgs.fetchFromGitHub {
+    owner = "hercules-ci";
+    repo = "gitignore.nix";
+    rev = "80463148cd97eebacf80ba68cf0043598f0d7438";
+    sha256 = "1l34rmh4lf4w8a1r8vsvkmg32l1chl0p593fl12r28xx83vn150v";
+  }) {}) gitignoreSource;
+
+  nixFilter = name: type: !(lib.hasSuffix ".nix" name);
+  srcFilter = src: lib.cleanSourceWith {
+    filter = nixFilter;
+    src = gitignoreSource src;
+  };
+
+in
 stdenv.mkDerivation rec {
   name = "immer-git";
   version = "git";
-  src = fetchGit ./.;
+  src = srcFilter ./.;
   nativeBuildInputs = [ cmake ];
   dontBuild = true;
+  dontUseCmakeBuildDir = true;
   meta = {
     homepage    = "https://github.com/arximboldi/immer";
     description = "Postmodern immutable data structures for C++";


### PR DESCRIPTION
This change removes the `const` qualifier from the static objects
containing empty rrbtree and champ nodes, and also modifies the methods
slightly so that they return a reference. This change makes it possible
for these types to be used as part of a garbage-collected runtime which
makes use of a copying collector, because if the user specifies a
heap_policy which allocates these nodes into a heap that needs to be
relocated during garbage collection, the garbage collector will need to
update the static pointer inside these methods in order to correctly
relocate these nodes.