### PR TITLE
Add diffing algorithm to maps

### DIFF
--- a/immer/detail/hamts/bits.hpp
+++ b/immer/detail/hamts/bits.hpp
@@ -125,6 +125,51 @@ inline count_t popcount(std::uint8_t x)
     return popcount(static_cast<std::uint32_t>(x));
 }
 
+template <typename bitmap_t>
+class set_bits_range
+{
+    bitmap_t bitmap;
+
+    class set_bits_iterator
+    {
+        bitmap_t bitmap;
+
+        inline static bitmap_t clearlsbit(bitmap_t bitmap)
+        {
+            return bitmap & (bitmap - 1);
+        }
+
+        inline static bitmap_t lsbit(bitmap_t bitmap)
+        {
+            return bitmap ^ clearlsbit(bitmap);
+        }
+
+    public:
+        set_bits_iterator(bitmap_t bitmap)
+            : bitmap(bitmap){};
+
+        set_bits_iterator operator++()
+        {
+            bitmap = clearlsbit(bitmap);
+            return *this;
+        }
+
+        bool operator!=(set_bits_iterator const& other) const
+        {
+            return bitmap != other.bitmap;
+        }
+
+        bitmap_t operator*() const { return lsbit(bitmap); }
+    };
+
+public:
+    set_bits_range(bitmap_t bitmap)
+        : bitmap(bitmap)
+    {}
+    set_bits_iterator begin() const { return set_bits_iterator(bitmap); }
+    set_bits_iterator end() const { return set_bits_iterator(0); }
+};
+
 } // namespace hamts
 } // namespace detail
 } // namespace immer

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -117,14 +117,14 @@ struct champ
     void diff(const champ& new_champ, Differ&& differ) const
     {
         diff<Differ, EqualValue>(
-            root, new_champ.root, 0, std::forward<Differ>(differ));
+            root, new_champ.root, 0, differ);
     }
 
     template <typename Differ, typename EqualValue>
     void diff(node_t* old_node,
               node_t* new_node,
               count_t depth,
-              Differ&& differ) const
+              Differ& differ) const
     {
         if (old_node == new_node)
             return;
@@ -185,29 +185,29 @@ struct champ
                     diff<Differ, EqualValue>(old_child,
                                              new_child,
                                              depth + 1,
-                                             std::forward<Differ>(differ));
+                                             differ);
                 } else if ((old_datamap & bit) && (new_nodemap & bit)) {
                     diff_data_node<Differ, EqualValue>(
                         old_node,
                         new_node,
                         bit,
                         depth,
-                        std::forward<Differ>(differ));
+                        differ);
                 } else if ((old_nodemap & bit) && (new_datamap & bit)) {
                     diff_node_data<Differ, EqualValue>(
                         old_node,
                         new_node,
                         bit,
                         depth,
-                        std::forward<Differ>(differ));
+                        differ);
                 } else if ((old_datamap & bit) && (new_datamap & bit)) {
                     diff_data_data<Differ, EqualValue>(
-                        old_node, new_node, bit, std::forward<Differ>(differ));
+                        old_node, new_node, bit, differ);
                 }
             }
         } else {
             diff_collisions<Differ, EqualValue>(
-                old_node, new_node, std::forward<Differ>(differ));
+                old_node, new_node, differ);
         }
     }
 
@@ -216,7 +216,7 @@ struct champ
                         node_t* new_node,
                         bitmap_t bit,
                         count_t depth,
-                        Differ&& differ) const
+                        Differ& differ) const
     {
         auto old_offset       = old_node->data_count(bit);
         auto const& old_value = old_node->values()[old_offset];
@@ -245,7 +245,7 @@ struct champ
                         node_t* new_node,
                         bitmap_t bit,
                         count_t depth,
-                        Differ&& differ) const
+                        Differ& differ) const
     {
         auto old_offset       = old_node->children_count(bit);
         auto old_child        = old_node->children()[old_offset];
@@ -273,7 +273,7 @@ struct champ
     void diff_data_data(node_t* old_node,
                         node_t* new_node,
                         bitmap_t bit,
-                        Differ&& differ) const
+                        Differ& differ) const
     {
         auto old_offset       = old_node->data_count(bit);
         auto new_offset       = new_node->data_count(bit);
@@ -290,7 +290,7 @@ struct champ
 
     template <typename Differ, typename EqualValue>
     void
-    diff_collisions(node_t* old_node, node_t* new_node, Differ&& differ) const
+    diff_collisions(node_t* old_node, node_t* new_node, Differ& differ) const
     {
         auto old_begin = old_node->collisions();
         auto old_end   = old_node->collisions() + old_node->collision_count();

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -648,7 +648,8 @@ struct node
                 auto merged = make_merged(
                     shift + B, std::move(v1), hash1, std::move(v2), hash2);
                 IMMER_TRY {
-                    return make_inner_n(1, idx1 >> shift, merged);
+                    return make_inner_n(
+                        1, static_cast<count_t>(idx1 >> shift), merged);
                 }
                 IMMER_CATCH (...) {
                     delete_deep_shift(merged, shift + B);
@@ -656,9 +657,9 @@ struct node
                 }
             } else {
                 return make_inner_n(0,
-                                    idx1 >> shift,
+                                    static_cast<count_t>(idx1 >> shift),
                                     std::move(v1),
-                                    idx2 >> shift,
+                                    static_cast<count_t>(idx2 >> shift),
                                     std::move(v2));
             }
         } else {

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -324,6 +324,19 @@ public:
                                   detail::constantly<const T*, nullptr>>(k);
     }
 
+    template <typename AddedFn, typename ChangedFn, typename RemovedFn>
+    void diff(map const& other,
+              AddedFn&& added_fn,
+              ChangedFn&& changed_fn,
+              RemovedFn&& removed_fn) const
+    {
+        return impl_.template diff<AddedFn, ChangedFn, RemovedFn>(
+            other.impl_,
+            std::forward<AddedFn>(added_fn),
+            std::forward<ChangedFn>(changed_fn),
+            std::forward<RemovedFn>(removed_fn));
+    }
+
     /*!
      * Returns whether the sets are equal.
      */

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -324,22 +324,6 @@ public:
                                   detail::constantly<const T*, nullptr>>(k);
     }
 
-    template <typename AddedFn,
-              typename ChangedFn,
-              typename RemovedFn,
-              typename EqualValue = equal_value>
-    void diff(map const& other,
-              AddedFn&& added_fn,
-              ChangedFn&& changed_fn,
-              RemovedFn&& removed_fn) const
-    {
-        return impl_.template diff<AddedFn, ChangedFn, RemovedFn, EqualValue>(
-            other.impl_,
-            std::forward<AddedFn>(added_fn),
-            std::forward<ChangedFn>(changed_fn),
-            std::forward<RemovedFn>(removed_fn));
-    }
-
     /*!
      * Returns whether the sets are equal.
      */

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -14,8 +14,8 @@
 #include <immer/memory_policy.hpp>
 
 #include <cassert>
-#include <stdexcept>
 #include <functional>
+#include <stdexcept>
 
 namespace immer {
 
@@ -324,13 +324,16 @@ public:
                                   detail::constantly<const T*, nullptr>>(k);
     }
 
-    template <typename AddedFn, typename ChangedFn, typename RemovedFn>
+    template <typename AddedFn,
+              typename ChangedFn,
+              typename RemovedFn,
+              typename EqualValue = equal_value>
     void diff(map const& other,
               AddedFn&& added_fn,
               ChangedFn&& changed_fn,
               RemovedFn&& removed_fn) const
     {
-        return impl_.template diff<AddedFn, ChangedFn, RemovedFn>(
+        return impl_.template diff<AddedFn, ChangedFn, RemovedFn, EqualValue>(
             other.impl_,
             std::forward<AddedFn>(added_fn),
             std::forward<ChangedFn>(changed_fn),

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -183,6 +183,18 @@ public:
         return !(*this == other);
     }
 
+    template <typename AddedFn, typename RemovedFn>
+    void diff(const set& other, AddedFn&& added, RemovedFn&& removed) const
+    {
+        // values can only be added or removed to sets, no changes possible
+        auto do_nothing = [](const auto&, const auto&) {};
+        impl_.template diff<AddedFn, decltype(do_nothing), RemovedFn, Equal>(
+            other.impl_,
+            std::forward<AddedFn>(added),
+            std::move(do_nothing),
+            std::forward<RemovedFn>(removed));
+    }
+
     /*!
      * Returns a set containing `value`.  If the `value` is already in
      * the set, it returns the same set.  It may allocate memory and

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -183,18 +183,6 @@ public:
         return !(*this == other);
     }
 
-    template <typename AddedFn, typename RemovedFn>
-    void diff(const set& other, AddedFn&& added, RemovedFn&& removed) const
-    {
-        // values can only be added or removed to sets, no changes possible
-        auto do_nothing = [](const auto&, const auto&) {};
-        impl_.template diff<AddedFn, decltype(do_nothing), RemovedFn, Equal>(
-            other.impl_,
-            std::forward<AddedFn>(added),
-            std::move(do_nothing),
-            std::forward<RemovedFn>(removed));
-    }
-
     /*!
      * Returns a set containing `value`.  If the `value` is already in
      * the set, it returns the same set.  It may allocate memory and

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -412,14 +412,14 @@ void test_diff(unsigned old_num,
         changed_keys.insert(key);
     }
 
-    first_snapshot.diff(
+    diff_with(first_snapshot,
         map,
         [&](auto const& data) { REQUIRE(added_keys.erase(data.first) > 0); },
+        [&](auto const& data) { REQUIRE(removed_keys.erase(data.first) > 0); },
         [&](auto const& old_data, auto const& new_data) {
             (void) old_data;
             REQUIRE(changed_keys.erase(new_data.first) > 0);
-        },
-        [&](auto const& data) { REQUIRE(removed_keys.erase(data.first) > 0); });
+        });
 
     CHECK(added_keys.empty());
     CHECK(changed_keys.empty());

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -39,6 +39,7 @@ struct conflictor
     {
         return v1 == x.v1 && v2 == x.v2;
     }
+    bool operator!=(const conflictor& other) const { return !(*this == other); }
 };
 
 struct hash_conflictor
@@ -363,3 +364,74 @@ TEST_CASE("issue 134")
 }
 
 } // namespace
+
+void test_diff(unsigned old_num,
+               unsigned add_num,
+               unsigned remove_num,
+               unsigned change_num)
+{
+    auto values = make_values_with_collisions(old_num + add_num);
+    std::vector<std::pair<conflictor, unsigned>> initial_values(
+        values.begin(), values.begin() + old_num);
+    std::vector<std::pair<conflictor, unsigned>> new_values(
+        values.begin() + old_num, values.end());
+    auto map = make_test_map(initial_values);
+
+    std::vector<conflictor> old_keys;
+    for (auto const& val : map)
+        old_keys.push_back(val.first);
+
+    auto first_snapshot = map;
+    CHECK(old_num == first_snapshot.size());
+
+    // remove
+    auto shuffle = old_keys;
+    std::random_shuffle(shuffle.begin(), shuffle.end());
+    std::vector<conflictor> remove_keys(shuffle.begin(),
+                                        shuffle.begin() + remove_num);
+    std::vector<conflictor> rest_keys(shuffle.begin() + remove_num,
+                                      shuffle.end());
+
+    using key_set = std::unordered_set<conflictor, hash_conflictor>;
+    key_set removed_keys(remove_keys.begin(), remove_keys.end());
+    for (auto const& key : remove_keys)
+        map = map.erase(key);
+    CHECK(old_num - remove_num == map.size());
+
+    // add
+    key_set added_keys;
+    for (auto const& data : new_values) {
+        map = map.set(data.first, data.second);
+        added_keys.insert(data.first);
+    }
+
+    // change
+    key_set changed_keys;
+    for (auto i = 0u; i < change_num; i++) {
+        auto key = rest_keys[i];
+        map      = map.update(key, [](auto val) { return ++val; });
+        changed_keys.insert(key);
+    }
+
+    first_snapshot.diff(
+        map,
+        [&](auto const& data) { REQUIRE(added_keys.erase(data.first) > 0); },
+        [&](auto const& old_data, auto const& new_data) {
+            (void) old_data;
+            REQUIRE(changed_keys.erase(new_data.first) > 0);
+        },
+        [&](auto const& data) { REQUIRE(removed_keys.erase(data.first) > 0); });
+
+    CHECK(added_keys.empty());
+    CHECK(changed_keys.empty());
+    CHECK(removed_keys.empty());
+}
+
+TEST_CASE("diff")
+{
+    test_diff(16, 10, 10, 3);
+    test_diff(100, 10, 10, 10);
+    test_diff(1500, 10, 1000, 100);
+    test_diff(16, 1500, 10, 3);
+    test_diff(100, 0, 0, 50);
+}

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -39,7 +39,6 @@ struct conflictor
     {
         return v1 == x.v1 && v2 == x.v2;
     }
-    bool operator!=(const conflictor& other) const { return !(*this == other); }
 };
 
 struct hash_conflictor

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -511,3 +511,54 @@ TEST_CASE("lookup with transparent hash")
         CHECK(m.count(LookupType{2}) == 0);
     }
 }
+
+
+void test_diff(unsigned old_num,
+               unsigned add_num,
+               unsigned remove_num)
+{
+    auto values = make_values_with_collisions(old_num + add_num);
+    std::vector<conflictor> initial_values(
+        values.begin(), values.begin() + old_num);
+    std::vector<conflictor> new_values(
+        values.begin() + old_num, values.end());
+    auto set = make_test_set(initial_values);
+
+    auto first_snapshot = set;
+    CHECK(old_num == first_snapshot.size());
+
+    // remove
+    auto shuffle = initial_values;
+    std::random_shuffle(shuffle.begin(), shuffle.end());
+    std::vector<conflictor> remove_keys(shuffle.begin(),
+                                        shuffle.begin() + remove_num);
+
+    using key_set = std::unordered_set<conflictor, hash_conflictor>;
+    key_set removed_keys(remove_keys.begin(), remove_keys.end());
+    for (auto const& key : remove_keys)
+        set = set.erase(key);
+    CHECK(old_num - remove_num == set.size());
+
+    // add
+    key_set added_keys;
+    for (auto const& data : new_values) {
+        set = set.insert(data);
+        added_keys.insert(data);
+    }
+
+    first_snapshot.diff(
+        set,
+        [&](auto const& data) { REQUIRE(added_keys.erase(data) > 0); },
+        [&](auto const& data) { REQUIRE(removed_keys.erase(data) > 0); });
+
+    CHECK(added_keys.empty());
+    CHECK(removed_keys.empty());
+}
+
+TEST_CASE("diff")
+{
+    test_diff(16, 10, 10);
+    test_diff(100, 10, 10);
+    test_diff(1500, 10, 1000);
+    test_diff(16, 1500, 10);
+}

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -512,16 +512,12 @@ TEST_CASE("lookup with transparent hash")
     }
 }
 
-
-void test_diff(unsigned old_num,
-               unsigned add_num,
-               unsigned remove_num)
+void test_diff(unsigned old_num, unsigned add_num, unsigned remove_num)
 {
     auto values = make_values_with_collisions(old_num + add_num);
-    std::vector<conflictor> initial_values(
-        values.begin(), values.begin() + old_num);
-    std::vector<conflictor> new_values(
-        values.begin() + old_num, values.end());
+    std::vector<conflictor> initial_values(values.begin(),
+                                           values.begin() + old_num);
+    std::vector<conflictor> new_values(values.begin() + old_num, values.end());
     auto set = make_test_set(initial_values);
 
     auto first_snapshot = set;
@@ -546,7 +542,8 @@ void test_diff(unsigned old_num,
         added_keys.insert(data);
     }
 
-    first_snapshot.diff(
+    diff_with(
+        first_snapshot,
         set,
         [&](auto const& data) { REQUIRE(added_keys.erase(data) > 0); },
         [&](auto const& data) { REQUIRE(removed_keys.erase(data) > 0); });


### PR DESCRIPTION
This is the implementation of a diff algorithm for immer::map. It compares two immer::map instances and calls respective lambda functions when keys were added or removed or when the value of a key changed. When data is shared among the two maps, the algorithm will not need to compare shared subtrees of the map.
We plan to use this for an undo feature.

The diff algorithm has following signature:
̂`map::diff(map const& other, AddedFn&& added, ChangedFn&& changed, RemovedFn&& Removed)`
 where the lambdas have the signature:
```
void AddedFn(std::pair<Key, Value> const& added_entry)
void ChangedFn(std::pair<Key, Value> const& old_item, std::pair<Key, Value> const& new_data)
void RemovedFn(std::pair<Key, Value> const& removed_entry)
```
Usage:
```
immer::map<int, int> old_snapshot; // initialize somehow
immer::map<int, int> new_snapshot = old_snapshot.set(1,2); // change somehow
old_snapshot.diff(
  new_snapshot,
  [](auto const& added){ std::cout << "added key " << added.first << std::endl; },
  [](auto const& old, auto const& new){
    std::cout << "changed key " << old.first << " from " << old.second << " to " << new.second << std::endl; },
  [](auto const& removed){ std::cout << "removed key " << removed.first << std::endl; }
  );
```
This signature works for our usecase, however we are happy for further input and would like to help to upstream this feature.

This partially addresses: #120