### PR TITLE
immer::array fix to prevent breakage with glm library

### DIFF
--- a/immer/detail/arrays/no_capacity.hpp
+++ b/immer/detail/arrays/no_capacity.hpp
@@ -108,7 +108,7 @@ struct no_capacity
                                bool> = true>
     static no_capacity from_range(Iter first, Sent last)
     {
-        auto count = static_cast<size_t>(distance(first, last));
+        auto count = static_cast<size_t>(std::distance(first, last));
         if (count == 0)
             return empty();
         else

--- a/immer/detail/arrays/with_capacity.hpp
+++ b/immer/detail/arrays/with_capacity.hpp
@@ -128,7 +128,7 @@ struct with_capacity
                                bool> = true>
     static with_capacity from_range(Iter first, Sent last)
     {
-        auto count = static_cast<size_t>(distance(first, last));
+        auto count = static_cast<size_t>(std::distance(first, last));
         if (count == 0)
             return empty();
         else


### PR DESCRIPTION
Tested with the following code

```cpp
#include <glm/glm.hpp>
#include "immer/array.hpp"

int main() {
    immer::array<glm::vec3> pos = {
        {0.f, 0.f, 0.f}
    };
}`
```

The error is
```
./immer/detail/arrays/with_capacity.hpp:131:22: error: invalid static_cast from type ‘const glm::vec<3, float, (glm::qualifier)0>*’ to type ‘immer::detail::arrays::with_capacity<glm::vec<3, float, (glm::qualifier)0>, immer::memory_policy<immer::free_list_heap_policy<immer::cpp_heap>, immer::refcount_policy, immer::spinlock_policy> >::size_t {aka long unsigned int}’
         auto count = static_cast<size_t>(distance(first, last));
```

glm provides a distance function which gets used by immer, somehow ...