### PR TITLE
Add Swift Package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,14 @@ jobs:
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: nix-build
 
+  build-spm:
+     runs-on: macos-latest
+     steps:
+       - uses: actions/checkout@v2
+         with:
+           submodules: true
+       - run: swift build
+
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ tools/clojure/.lein*
 *.pyc
 
 /result*
+
+.build
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "immer",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "immer",
+            targets: ["immer"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "immer",
+            dependencies: [],
+            path: ".",
+            sources: ["spm.cpp"],
+            publicHeadersPath: ".")
+    ],
+    cxxLanguageStandard: .cxx20
+)

--- a/Package.swift
+++ b/Package.swift
@@ -25,5 +25,5 @@ let package = Package(
             sources: ["spm.cpp"],
             publicHeadersPath: ".")
     ],
-    cxxLanguageStandard: .cxx20
+    cxxLanguageStandard: .cxx14
 )

--- a/spm.cpp
+++ b/spm.cpp
@@ -1,0 +1,4 @@
+
+#include <immer/vector.hpp>
+
+// Just so we can compile with SPM.


### PR DESCRIPTION
Adds a Swift Package so immer can be used easily in Xcode projects. SPM doesn't know about header-only libraries, so it required adding a source file (spm.cpp). We can move this file wherever you want.