### PR TITLE
Sketch transients for HAMT-based data-structures

### DIFF
--- a/benchmark/set/insert.hpp
+++ b/benchmark/set/insert.hpp
@@ -51,4 +51,20 @@ auto benchmark_insert()
     };
 }
 
+template <typename Generator, typename Set>
+auto benchmark_insert_move()
+{
+    return [](nonius::chronometer meter) {
+        auto n = meter.param<N>();
+        auto g = Generator{}(n);
+
+        measure(meter, [&] {
+            auto v = Set{};
+            for (auto i = 0u; i < n; ++i)
+                v = std::move(v).insert(g[i]);
+            return v;
+        });
+    };
+}
+
 } // namespace

--- a/benchmark/set/insert.hpp
+++ b/benchmark/set/insert.hpp
@@ -10,9 +10,10 @@
 
 #include "benchmark/config.hpp"
 
-#include <immer/set.hpp>
-#include <hash_trie.hpp> // Phil Nash
 #include <boost/container/flat_set.hpp>
+#include <hash_trie.hpp> // Phil Nash
+#include <immer/set.hpp>
+#include <immer/set_transient.hpp>
 #include <set>
 #include <unordered_set>
 
@@ -21,8 +22,7 @@ namespace {
 template <typename Generator, typename Set>
 auto benchmark_insert_mut_std()
 {
-    return [] (nonius::chronometer meter)
-    {
+    return [](nonius::chronometer meter) {
         auto n = meter.param<N>();
         auto g = Generator{}(n);
 
@@ -38,8 +38,7 @@ auto benchmark_insert_mut_std()
 template <typename Generator, typename Set>
 auto benchmark_insert()
 {
-    return [] (nonius::chronometer meter)
-    {
+    return [](nonius::chronometer meter) {
         auto n = meter.param<N>();
         auto g = Generator{}(n);
 

--- a/benchmark/set/insert.ipp
+++ b/benchmark/set/insert.ipp
@@ -13,8 +13,9 @@
 #endif
 
 using generator__ = GENERATOR_T;
-using t__ = typename decltype(generator__{}(0))::value_type;
+using t__         = typename decltype(generator__{}(0))::value_type;
 
+// clang-format off
 NONIUS_BENCHMARK("std::set", benchmark_insert_mut_std<generator__, std::set<t__>>())
 NONIUS_BENCHMARK("std::unordered_set", benchmark_insert_mut_std<generator__, std::unordered_set<t__>>())
 NONIUS_BENCHMARK("boost::flat_set", benchmark_insert_mut_std<generator__, boost::container::flat_set<t__>>())
@@ -26,3 +27,20 @@ NONIUS_BENCHMARK("immer::set/4B", benchmark_insert<generator__, immer::set<t__, 
 NONIUS_BENCHMARK("immer::set/GC", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,gc_memory,5>>())
 #endif
 NONIUS_BENCHMARK("immer::set/UN", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,unsafe_memory,5>>())
+
+NONIUS_BENCHMARK("immer::set/5B", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,5>>())
+NONIUS_BENCHMARK("immer::set/4B", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,4>>())
+#ifndef DISABLE_GC_BENCHMARKS
+NONIUS_BENCHMARK("immer::set/GC", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,gc_memory,5>>())
+#endif
+NONIUS_BENCHMARK("immer::set/UN", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,unsafe_memory,5>>())
+
+NONIUS_BENCHMARK("immer::set/move/5B", benchmark_insert_move<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,5>>())
+NONIUS_BENCHMARK("immer::set/move/4B", benchmark_insert_move<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,4>>())
+NONIUS_BENCHMARK("immer::set/move/UN", benchmark_insert_move<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,unsafe_memory,5>>())
+
+NONIUS_BENCHMARK("immer::set/tran/5B", benchmark_insert_mut_std<generator__, immer::set_transient<t__, std::hash<t__>,std::equal_to<t__>,def_memory,5>>())
+NONIUS_BENCHMARK("immer::set/tran/4B", benchmark_insert_mut_std<generator__, immer::set_transient<t__, std::hash<t__>,std::equal_to<t__>,def_memory,4>>())
+NONIUS_BENCHMARK("immer::set/tran/UN", benchmark_insert_mut_std<generator__, immer::set_transient<t__, std::hash<t__>,std::equal_to<t__>,unsafe_memory,5>>())
+
+// clang-format on

--- a/extra/fuzzer/fuzzer_input.hpp
+++ b/extra/fuzzer/fuzzer_input.hpp
@@ -12,6 +12,10 @@
 #include <memory>
 #include <stdexcept>
 
+#if defined(__GNUC__) && (__GNUC__ == 9 || __GNUC__ == 8 || __GNUC__ == 10)
+#define IMMER_DISABLE_FUZZER_DUE_TO_GCC_BUG 1
+#endif
+
 struct no_more_input : std::exception
 {};
 

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -164,6 +164,29 @@ public:
     using transient_type = map_transient<K, T, Hash, Equal, MemoryPolicy, B>;
 
     /*!
+     * Constructs a map containing the elements in `values`.
+     */
+    map(std::initializer_list<value_type> values)
+    {
+        for (auto&& v : values)
+            *this = std::move(*this).insert(v);
+    }
+
+    /*!
+     * Constructs a map containing the elements in the range
+     * defined by the input iterator `first` and range sentinel `last`.
+     */
+    template <typename Iter,
+              typename Sent,
+              std::enable_if_t<detail::compatible_sentinel_v<Iter, Sent>,
+                               bool> = true>
+    map(Iter first, Sent last)
+    {
+        for (; first != last; ++first)
+            *this = std::move(*this).insert(*first);
+    }
+
+    /*!
      * Default constructor.  It creates a map of `size() == 0`.  It
      * does not allocate memory and its complexity is @f$ O(1) @f$.
      */

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -114,8 +114,11 @@ class map
     {
         auto operator()(const value_t& v) { return Hash{}(v.first); }
 
-        template<typename Key>
-        auto operator()(const Key& v) { return Hash{}(v); }
+        template <typename Key>
+        auto operator()(const Key& v)
+        {
+            return Hash{}(v);
+        }
     };
 
     struct equal_key
@@ -125,7 +128,7 @@ class map
             return Equal{}(a.first, b.first);
         }
 
-        template<typename Key>
+        template <typename Key>
         auto operator()(const value_t& a, const Key& b)
         {
             return Equal{}(a.first, b);
@@ -161,7 +164,7 @@ public:
     using transient_type = map_transient<K, T, Hash, Equal, MemoryPolicy, B>;
 
     /*!
-     * Default constructor.  It creates a set of `size() == 0`.  It
+     * Default constructor.  It creates a map of `size() == 0`.  It
      * does not allocate memory and its complexity is @f$ O(1) @f$.
      */
     map() = default;
@@ -202,7 +205,9 @@ public:
      * This overload participates in overload resolution only if
      * `Hash::is_transparent` is valid and denotes a type.
      */
-    template<typename Key, typename U = Hash, typename = typename U::is_transparent>
+    template <typename Key,
+              typename U = Hash,
+              typename   = typename U::is_transparent>
     IMMER_NODISCARD size_type count(const Key& k) const
     {
         return impl_.template get<detail::constantly<size_type, 1>,
@@ -229,7 +234,9 @@ public:
      * This overload participates in overload resolution only if
      * `Hash::is_transparent` is valid and denotes a type.
      */
-    template<typename Key, typename U = Hash, typename = typename U::is_transparent>
+    template <typename Key,
+              typename U = Hash,
+              typename   = typename U::is_transparent>
     IMMER_NODISCARD const T& operator[](const Key& k) const
     {
         return impl_.template get<project_value, default_value>(k);
@@ -252,7 +259,9 @@ public:
      * `std::out_of_range` error.  It does not allocate memory and its
      * complexity is *effectively* @f$ O(1) @f$.
      */
-    template<typename Key, typename U = Hash, typename = typename U::is_transparent>
+    template <typename Key,
+              typename U = Hash,
+              typename   = typename U::is_transparent>
     const T& at(const Key& k) const
     {
         return impl_.template get<project_value, error_value>(k);
@@ -307,7 +316,6 @@ public:
                                   detail::constantly<const T*, nullptr>>(k);
     }
 
-
     /*!
      * Returns a pointer to the value associated with the key `k`.  If
      * the key is not contained in the map, a `nullptr` is returned.
@@ -317,7 +325,9 @@ public:
      * This overload participates in overload resolution only if
      * `Hash::is_transparent` is valid and denotes a type.
      */
-    template<typename Key, typename U = Hash, typename = typename U::is_transparent>
+    template <typename Key,
+              typename U = Hash,
+              typename   = typename U::is_transparent>
     IMMER_NODISCARD const T* find(const Key& k) const
     {
         return impl_.template get<project_value_ptr,

--- a/immer/map_transient.hpp
+++ b/immer/map_transient.hpp
@@ -36,6 +36,44 @@ template <typename K,
           typename Equal          = std::equal_to<K>,
           typename MemoryPolicy   = default_memory_policy,
           detail::hamts::bits_t B = default_bits>
-class map_transient;
+class map_transient : MemoryPolicy::transience_t::owner
+{
+    using base_t = typename MemoryPolicy::transience_t::owner;
+
+public:
+    using persistent_type = map<K, T, Hash, Equal, MemoryPolicy, B>;
+
+    using key_type        = K;
+    using mapped_type     = T;
+    using value_type      = std::pair<K, T>;
+    using size_type       = detail::hamts::size_t;
+    using diference_type  = std::ptrdiff_t;
+    using hasher          = Hash;
+    using key_equal       = Equal;
+    using reference       = const value_type&;
+    using const_reference = const value_type&;
+
+    using iterator       = typename persistent_type::iterator;
+    using const_iterator = iterator;
+
+    /*!
+     * Default constructor.  It creates a map of `size() == 0`.  It
+     * does not allocate memory and its complexity is @f$ O(1) @f$.
+     */
+    map_transient() = default;
+
+    IMMER_NODISCARD persistent_type persistent() & { return impl_; }
+    IMMER_NODISCARD persistent_type persistent() && { return std::move(impl_); }
+
+private:
+    friend persistent_type;
+    using impl_t = typename persistent_type::impl_t;
+
+    map_transient(impl_t impl)
+        : impl_(std::move(impl))
+    {}
+
+    impl_t impl_ = impl_t::empty();
+};
 
 } // namespace immer

--- a/immer/map_transient.hpp
+++ b/immer/map_transient.hpp
@@ -38,7 +38,8 @@ template <typename K,
           detail::hamts::bits_t B = default_bits>
 class map_transient : MemoryPolicy::transience_t::owner
 {
-    using base_t = typename MemoryPolicy::transience_t::owner;
+    using base_t  = typename MemoryPolicy::transience_t::owner;
+    using owner_t = base_t;
 
 public:
     using persistent_type = map<K, T, Hash, Equal, MemoryPolicy, B>;
@@ -62,7 +63,233 @@ public:
      */
     map_transient() = default;
 
-    IMMER_NODISCARD persistent_type persistent() & { return impl_; }
+    /*!
+     * Returns an iterator pointing at the first element of the
+     * collection. It does not allocate memory and its complexity is
+     * @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD iterator begin() const { return {impl_}; }
+
+    /*!
+     * Returns an iterator pointing just after the last element of the
+     * collection. It does not allocate and its complexity is @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD iterator end() const
+    {
+        return {impl_, typename iterator::end_t{}};
+    }
+
+    /*!
+     * Returns the number of elements in the container.  It does
+     * not allocate memory and its complexity is @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD size_type size() const { return impl_.size; }
+
+    /*!
+     * Returns `true` if there are no elements in the container.  It
+     * does not allocate memory and its complexity is @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD bool empty() const { return impl_.size == 0; }
+
+    /*!
+     * Returns `1` when the key `k` is contained in the map or `0`
+     * otherwise. It won't allocate memory and its complexity is
+     * *effectively* @f$ O(1) @f$.
+     *
+     * This overload participates in overload resolution only if
+     * `Hash::is_transparent` is valid and denotes a type.
+     */
+    template <typename Key,
+              typename U = Hash,
+              typename   = typename U::is_transparent>
+    IMMER_NODISCARD size_type count(const Key& k) const
+    {
+        return impl_.template get<detail::constantly<size_type, 1>,
+                                  detail::constantly<size_type, 0>>(k);
+    }
+
+    /*!
+     * Returns `1` when the key `k` is contained in the map or `0`
+     * otherwise. It won't allocate memory and its complexity is
+     * *effectively* @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD size_type count(const K& k) const
+    {
+        return impl_.template get<detail::constantly<size_type, 1>,
+                                  detail::constantly<size_type, 0>>(k);
+    }
+
+    /*!
+     * Returns a `const` reference to the values associated to the key
+     * `k`.  If the key is not contained in the map, it returns a
+     * default constructed value.  It does not allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     *
+     * This overload participates in overload resolution only if
+     * `Hash::is_transparent` is valid and denotes a type.
+     */
+    template <typename Key,
+              typename U = Hash,
+              typename   = typename U::is_transparent>
+    IMMER_NODISCARD const T& operator[](const Key& k) const
+    {
+        return impl_.template get<typename persistent_type::project_value,
+                                  typename persistent_type::default_value>(k);
+    }
+
+    /*!
+     * Returns a `const` reference to the values associated to the key
+     * `k`.  If the key is not contained in the map, it returns a
+     * default constructed value.  It does not allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD const T& operator[](const K& k) const
+    {
+        return impl_.template get<typename persistent_type::project_value,
+                                  typename persistent_type::default_value>(k);
+    }
+
+    /*!
+     * Returns a `const` reference to the values associated to the key
+     * `k`.  If the key is not contained in the map, throws an
+     * `std::out_of_range` error.  It does not allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     */
+    template <typename Key,
+              typename U = Hash,
+              typename   = typename U::is_transparent>
+    const T& at(const Key& k) const
+    {
+        return impl_.template get<typename persistent_type::project_value,
+                                  typename persistent_type::error_value>(k);
+    }
+
+    /*!
+     * Returns a `const` reference to the values associated to the key
+     * `k`.  If the key is not contained in the map, throws an
+     * `std::out_of_range` error.  It does not allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     *
+     * This overload participates in overload resolution only if
+     * `Hash::is_transparent` is valid and denotes a type.
+     */
+    const T& at(const K& k) const
+    {
+        return impl_.template get<typename persistent_type::project_value,
+                                  typename persistent_type::error_value>(k);
+    }
+
+    /*!
+     * Returns a pointer to the value associated with the key `k`.  If
+     * the key is not contained in the map, a `nullptr` is returned.
+     * It does not allocate memory and its complexity is *effectively*
+     * @f$ O(1) @f$.
+     *
+     * @rst
+     *
+     * .. admonition:: Why doesn't this function return an iterator?
+     *
+     *   Associative containers from the C++ standard library provide a
+     *   ``find`` method that returns an iterator pointing to the
+     *   element in the container or ``end()`` when the key is missing.
+     *   In the case of an unordered container, the only meaningful
+     *   thing one may do with it is to compare it with the end, to
+     *   test if the find was succesfull, and dereference it.  This
+     *   comparison is cumbersome compared to testing for a non-empty
+     *   optional value.  Furthermore, for an immutable container,
+     *   returning an iterator would have some additional performance
+     *   cost, with no benefits otherwise.
+     *
+     *   In our opinion, this function should return a
+     *   ``std::optional<const T&>`` but this construction is not valid
+     *   in any current standard.  As a compromise we return a
+     *   pointer, which has similar syntactic properties yet it is
+     *   unfortunately unnecessarily unrestricted.
+     *
+     * @endrst
+     */
+    IMMER_NODISCARD const T* find(const K& k) const
+    {
+        return impl_.template get<typename persistent_type::project_value_ptr,
+                                  detail::constantly<const T*, nullptr>>(k);
+    }
+
+    /*!
+     * Returns a pointer to the value associated with the key `k`.  If
+     * the key is not contained in the map, a `nullptr` is returned.
+     * It does not allocate memory and its complexity is *effectively*
+     * @f$ O(1) @f$.
+     *
+     * This overload participates in overload resolution only if
+     * `Hash::is_transparent` is valid and denotes a type.
+     */
+    template <typename Key,
+              typename U = Hash,
+              typename   = typename U::is_transparent>
+    IMMER_NODISCARD const T* find(const Key& k) const
+    {
+        return impl_.template get<typename persistent_type::project_value_ptr,
+                                  detail::constantly<const T*, nullptr>>(k);
+    }
+
+    /*!
+     * Inserts the association `value`.  If the key is already in the map, it
+     * replaces its association in the map.  It may allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     */
+    void insert(value_type value)
+    {
+        // xxx: implement mutable version
+        impl_ = impl_.add(std::move(value));
+    }
+
+    /*!
+     * Inserts the association `(k, v)`.  If the key is already in the map, it
+     * replaces its association in the map.  It may allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     */
+    void set(key_type k, mapped_type v)
+    {
+        // xxx: implement mutable version
+        impl_ = impl_.add({std::move(k), std::move(v)});
+    }
+
+    /*!
+     * Replaces the association `(k, v)` by the association new association `(k,
+     * fn(v))`, where `v` is the currently associated value for `k` in the map
+     * or a default constructed value otherwise. It may allocate memory and its
+     * complexity is *effectively* @f$ O(1) @f$.
+     */
+    template <typename Fn>
+    void update(key_type k, Fn&& fn)
+    {
+        // xxx: implement mutable version
+        impl_ = impl_.template update<persistent_type::project_value,
+                                      persistent_type::default_value,
+                                      persistent_type::combine_value>(
+            std::move(k), std::forward<Fn>(fn));
+    }
+
+    /*!
+     * Removes the key `k` from the k.  Does nothing if the key is not
+     * associated in the map.  It may allocate memory and its complexity is
+     * *effectively* @f$ O(1) @f$.
+     */
+    void erase(const K& k)
+    {
+        // xxx: implement mutable version
+        impl_ = impl_.sub(k);
+    }
+
+    /*!
+     * Returns an @a immutable form of this container, an
+     * `immer::map`.
+     */
+    IMMER_NODISCARD persistent_type persistent() &
+    {
+        this->owner_t::operator=(owner_t{});
+        return impl_;
+    }
     IMMER_NODISCARD persistent_type persistent() && { return std::move(impl_); }
 
 private:
@@ -74,6 +301,10 @@ private:
     {}
 
     impl_t impl_ = impl_t::empty();
+
+public:
+    // Semi-private
+    const impl_t& impl() const { return impl_; }
 };
 
 } // namespace immer

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -68,7 +68,6 @@ class set
     };
 
 public:
-    using key_type        = T;
     using value_type      = T;
     using size_type       = detail::hamts::size_t;
     using diference_type  = std::ptrdiff_t;
@@ -125,7 +124,9 @@ public:
      * This overload participates in overload resolution only if
      * `Hash::is_transparent` is valid and denotes a type.
      */
-    template<typename K, typename U = Hash, typename = typename U::is_transparent>
+    template <typename K,
+              typename U = Hash,
+              typename   = typename U::is_transparent>
     IMMER_NODISCARD size_type count(const K& value) const
     {
         return impl_.template get<detail::constantly<size_type, 1>,
@@ -164,7 +165,9 @@ public:
      * This overload participates in overload resolution only if
      * `Hash::is_transparent` is valid and denotes a type.
      */
-    template<typename K, typename U = Hash, typename = typename U::is_transparent>
+    template <typename K,
+              typename U = Hash,
+              typename   = typename U::is_transparent>
     IMMER_NODISCARD const T* find(const K& value) const
     {
         return impl_.template get<project_value_ptr,

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -89,6 +89,29 @@ public:
     set() = default;
 
     /*!
+     * Constructs a set containing the elements in `values`.
+     */
+    set(std::initializer_list<value_type> values)
+    {
+        for (auto&& v : values)
+            *this = std::move(*this).insert(v);
+    }
+
+    /*!
+     * Constructs a set containing the elements in the range
+     * defined by the input iterator `first` and range sentinel `last`.
+     */
+    template <typename Iter,
+              typename Sent,
+              std::enable_if_t<detail::compatible_sentinel_v<Iter, Sent>,
+                               bool> = true>
+    set(Iter first, Sent last)
+    {
+        for (; first != last; ++first)
+            *this = std::move(*this).insert(*first);
+    }
+
+    /*!
      * Returns an iterator pointing at the first element of the
      * collection. It does not allocate memory and its complexity is
      * @f$ O(1) @f$.

--- a/immer/set_transient.hpp
+++ b/immer/set_transient.hpp
@@ -35,6 +35,35 @@ template <typename T,
           typename Equal          = std::equal_to<T>,
           typename MemoryPolicy   = default_memory_policy,
           detail::hamts::bits_t B = default_bits>
-class set_transient;
+class set_transient : MemoryPolicy::transience_t::owner
+{
+    using base_t = typename MemoryPolicy::transience_t::owner;
+
+public:
+    using value_type      = T;
+    using size_type       = detail::hamts::size_t;
+    using diference_type  = std::ptrdiff_t;
+    using hasher          = Hash;
+    using key_equal       = Equal;
+    using reference       = const T&;
+    using const_reference = const T&;
+
+    using persistent_type = set<T, Hash, Equal, MemoryPolicy, B>;
+
+    set_transient() = default;
+
+    IMMER_NODISCARD persistent_type persistent() & { return {}; }
+    IMMER_NODISCARD persistent_type persistent() && { return {}; }
+
+private:
+    friend persistent_type;
+    using impl_t = typename persistent_type::impl_t;
+
+    set_transient(impl_t impl)
+        : impl_(std::move(impl))
+    {}
+
+    impl_t impl_ = impl_t::empty();
+};
 
 } // namespace immer

--- a/immer/set_transient.hpp
+++ b/immer/set_transient.hpp
@@ -37,9 +37,12 @@ template <typename T,
           detail::hamts::bits_t B = default_bits>
 class set_transient : MemoryPolicy::transience_t::owner
 {
-    using base_t = typename MemoryPolicy::transience_t::owner;
+    using base_t  = typename MemoryPolicy::transience_t::owner;
+    using owner_t = base_t;
 
 public:
+    using persistent_type = set<T, Hash, Equal, MemoryPolicy, B>;
+
     using value_type      = T;
     using size_type       = detail::hamts::size_t;
     using diference_type  = std::ptrdiff_t;
@@ -48,12 +51,133 @@ public:
     using reference       = const T&;
     using const_reference = const T&;
 
-    using persistent_type = set<T, Hash, Equal, MemoryPolicy, B>;
+    using iterator       = typename persistent_type::iterator;
+    using const_iterator = iterator;
 
+    /*!
+     * Default constructor.  It creates a set of `size() == 0`.  It
+     * does not allocate memory and its complexity is @f$ O(1) @f$.
+     */
     set_transient() = default;
 
-    IMMER_NODISCARD persistent_type persistent() & { return {}; }
-    IMMER_NODISCARD persistent_type persistent() && { return {}; }
+    /*!
+     * Returns an iterator pointing at the first element of the
+     * collection. It does not allocate memory and its complexity is
+     * @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD iterator begin() const { return {impl_}; }
+
+    /*!
+     * Returns an iterator pointing just after the last element of the
+     * collection. It does not allocate and its complexity is @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD iterator end() const
+    {
+        return {impl_, typename iterator::end_t{}};
+    }
+
+    /*!
+     * Returns the number of elements in the container.  It does
+     * not allocate memory and its complexity is @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD size_type size() const { return impl_.size; }
+
+    /*!
+     * Returns `true` if there are no elements in the container.  It
+     * does not allocate memory and its complexity is @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD bool empty() const { return impl_.size == 0; }
+
+    /*!
+     * Returns `1` when `value` is contained in the set or `0`
+     * otherwise. It won't allocate memory and its complexity is
+     * *effectively* @f$ O(1) @f$.
+     *
+     * This overload participates in overload resolution only if
+     * `Hash::is_transparent` is valid and denotes a type.
+     */
+    template <typename K,
+              typename U = Hash,
+              typename   = typename U::is_transparent>
+    IMMER_NODISCARD size_type count(const K& value) const
+    {
+        return impl_.template get<detail::constantly<size_type, 1>,
+                                  detail::constantly<size_type, 0>>(value);
+    }
+
+    /*!
+     * Returns `1` when `value` is contained in the set or `0`
+     * otherwise. It won't allocate memory and its complexity is
+     * *effectively* @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD size_type count(const T& value) const
+    {
+        return impl_.template get<detail::constantly<size_type, 1>,
+                                  detail::constantly<size_type, 0>>(value);
+    }
+
+    /*!
+     * Returns a pointer to the value if `value` is contained in the
+     * set, or nullptr otherwise.
+     * It does not allocate memory and its complexity is *effectively*
+     * @f$ O(1) @f$.
+     */
+    IMMER_NODISCARD const T* find(const T& value) const
+    {
+        return impl_.template get<typename persistent_type::project_value_ptr,
+                                  detail::constantly<const T*, nullptr>>(value);
+    }
+
+    /*!
+     * Returns a pointer to the value if `value` is contained in the
+     * set, or nullptr otherwise.
+     * It does not allocate memory and its complexity is *effectively*
+     * @f$ O(1) @f$.
+     *
+     * This overload participates in overload resolution only if
+     * `Hash::is_transparent` is valid and denotes a type.
+     */
+    template <typename K,
+              typename U = Hash,
+              typename   = typename U::is_transparent>
+    IMMER_NODISCARD const T* find(const K& value) const
+    {
+        return impl_.template get<typename persistent_type::project_value_ptr,
+                                  detail::constantly<const T*, nullptr>>(value);
+    }
+
+    /*!
+     * Inserts `value` into the set, and does nothing if the value is already
+     * there  It may allocate memory and its complexity is *effectively* @f$
+     * O(1) @f$.
+     */
+    void insert(T value)
+    {
+        // xxx: implement mutable version
+        impl_ = impl_.add(std::move(value));
+    }
+
+    /*!
+     * Removes the `value` from the set, doing nothing if the value is not in
+     * the set.  It may allocate memory and its complexity is *effectively* @f$
+     * O(1) @f$.
+     */
+    void erase(const T& value)
+    {
+        // xxx: implement mutable version
+        impl_ = impl_.sub(value);
+    }
+
+    /*!
+     * Returns an @a immutable form of this container, an
+     * `immer::set`.
+     */
+    IMMER_NODISCARD persistent_type persistent() &
+    {
+        this->owner_t::operator=(owner_t{});
+        return impl_;
+    }
+    IMMER_NODISCARD persistent_type persistent() && { return std::move(impl_); }
 
 private:
     friend persistent_type;
@@ -64,6 +188,10 @@ private:
     {}
 
     impl_t impl_ = impl_t::empty();
+
+public:
+    // Semi-private
+    const impl_t& impl() const { return impl_; }
 };
 
 } // namespace immer

--- a/test/flex_vector/fuzzed-0.cpp
+++ b/test/flex_vector/fuzzed-0.cpp
@@ -174,7 +174,7 @@ TEST_CASE("bug: concatenate too big vectors")
         var4      = var4.push_back(42);
     }
 
-#if __GNUC__ != 9 && __GNUC__ != 8
+#ifndef IMMER_DISABLE_FUZZER_DUE_TO_GCC_BUG
     // Assertion `!p->relaxed()' failed
     SECTION("")
     {

--- a/test/flex_vector/fuzzed-1.cpp
+++ b/test/flex_vector/fuzzed-1.cpp
@@ -159,7 +159,7 @@ TEST_CASE("bug: memory leak because of move update")
         var0      = std::move(var0).push_back(21);
     }
 
-#if __GNUC__ != 9 && __GNUC__ != 8
+#if !IMMER_DISABLE_FUZZER_DUE_TO_GCC_BUG
     SECTION("")
     {
         constexpr std::uint8_t input[] = {
@@ -263,7 +263,8 @@ TEST_CASE("non-bug: crash")
         var4      = var4 + var4;
         var4      = var4.update(4, [](auto x) { return x + 1; });
     }
-#if __GNUC__ != 9 && __GNUC__ != 8
+
+#ifndef IMMER_DISABLE_FUZZER_DUE_TO_GCC_BUG
     SECTION("")
     {
         constexpr std::uint8_t input[] = {

--- a/test/flex_vector/fuzzed-2.cpp
+++ b/test/flex_vector/fuzzed-2.cpp
@@ -172,7 +172,7 @@ TEST_CASE("bug: use after free on move-take")
         var0      = std::move(var0).take(68);
     }
 
-#if __GNUC__ != 9 && __GNUC__ != 8
+#ifndef IMMER_DISABLE_FUZZER_DUE_TO_GCC_BUG
     SECTION("")
     {
         constexpr std::uint8_t input[] = {

--- a/test/flex_vector/fuzzed-3.cpp
+++ b/test/flex_vector/fuzzed-3.cpp
@@ -205,7 +205,7 @@ TEST_CASE("bug: concat with moving the right side")
         var0      = var0 + std::move(var1);
     }
 
-#if __GNUC__ != 9 && __GNUC__ != 8
+#ifndef IMMER_DISABLE_FUZZER_DUE_TO_GCC_BUG
     SECTION("vm")
     {
         constexpr std::uint8_t input[] = {

--- a/test/flex_vector/fuzzed-4.cpp
+++ b/test/flex_vector/fuzzed-4.cpp
@@ -231,7 +231,7 @@ TEST_CASE("bug: concatenating transients")
         t1.append(t0);
     }
 
-#if __GNUC__ != 9 && __GNUC__ != 8
+#if !IMMER_DISABLE_FUZZER_DUE_TO_GCC_BUG
     SECTION("")
     {
         constexpr std::uint8_t input[] = {
@@ -271,7 +271,7 @@ TEST_CASE("bug: concatenating moved transients")
         t2.append(std::move(t0));
     }
 
-#if __GNUC__ != 9 && __GNUC__ != 8
+#ifndef IMMER_DISABLE_FUZZER_DUE_TO_GCC_BUG
     SECTION("")
     {
         constexpr std::uint8_t input[] = {
@@ -309,7 +309,7 @@ TEST_CASE("bug: concatenating moved transients")
         t0 = {};
     }
 
-#if __GNUC__ != 9 && __GNUC__ != 8
+#if !IMMER_DISABLE_FUZZER_DUE_TO_GCC_BUG
     SECTION("")
     {
         return;
@@ -348,7 +348,7 @@ TEST_CASE("bug: aegsdas")
         t1 = {};
     }
 
-#if __GNUC__ != 9 && __GNUC__ != 8
+#ifndef IMMER_DISABLE_FUZZER_DUE_TO_GCC_BUG
     SECTION("")
     {
         constexpr std::uint8_t input[] = {

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -20,6 +20,7 @@
 #include <catch.hpp>
 
 #include <random>
+#include <unordered_map>
 #include <unordered_set>
 
 template <typename T = unsigned>
@@ -100,6 +101,19 @@ TEST_CASE("basic insertion")
     CHECK(v1.count(42) == 0);
     CHECK(v2.count(42) == 1);
     CHECK(v3.count(42) == 1);
+}
+
+TEST_CASE("initializer list and range constructors")
+{
+    auto v0 = std::unordered_map<std::string, int>{
+        {{"foo", 42}, {"bar", 13}, {"baz", 18}, {"zab", 64}}};
+    auto v1 = MAP_T<std::string, int>{
+        {{"foo", 42}, {"bar", 13}, {"baz", 18}, {"zab", 64}}};
+    auto v2 = MAP_T<std::string, int>{v0.begin(), v0.end()};
+    CHECK(v1.size() == 4);
+    CHECK(v1.count(std::string{"foo"}) == 1);
+    CHECK(v1.at(std::string{"bar"}) == 13);
+    CHECK(v1 == v2);
 }
 
 TEST_CASE("accessor")

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -67,7 +67,7 @@ auto make_test_map(unsigned n)
 {
     auto s = MAP_T<unsigned, unsigned>{};
     for (auto i = 0u; i < n; ++i)
-        s = s.insert({i, i});
+        s = std::move(s).insert({i, i});
     return s;
 }
 
@@ -75,7 +75,7 @@ auto make_test_map(const std::vector<std::pair<conflictor, unsigned>>& vals)
 {
     auto s = MAP_T<conflictor, unsigned, hash_conflictor>{};
     for (auto&& v : vals)
-        s = s.insert(v);
+        s = std::move(s).insert(v);
     return s;
 }
 
@@ -230,9 +230,19 @@ TEST_CASE("update a lot")
 {
     auto v = make_test_map(666u);
 
-    for (decltype(v.size()) i = 0; i < v.size(); ++i) {
-        v = v.update(i, [](auto&& x) { return x + 1; });
-        CHECK(v[i] == i + 1);
+    SECTION("immutable")
+    {
+        for (decltype(v.size()) i = 0; i < v.size(); ++i) {
+            v = v.update(i, [](auto&& x) { return x + 1; });
+            CHECK(v[i] == i + 1);
+        }
+    }
+    SECTION("move")
+    {
+        for (decltype(v.size()) i = 0; i < v.size(); ++i) {
+            v = std::move(v).update(i, [](auto&& x) { return x + 1; });
+            CHECK(v[i] == i + 1);
+        }
     }
 }
 
@@ -250,7 +260,7 @@ TEST_CASE("exception safety")
         auto v = dadaist_map_t{};
         auto d = dadaism{};
         for (auto i = 0u; i < n; ++i)
-            v = v.set(i, i);
+            v = std::move(v).set(i, i);
         for (auto i = 0u; i < v.size();) {
             try {
                 auto s = d.next();
@@ -277,6 +287,29 @@ TEST_CASE("exception safety")
             try {
                 auto s = d.next();
                 v      = v.update(vals[i].first, [](auto x) { return x + 1; });
+                ++i;
+            } catch (dada_error) {}
+            for (auto i : test_irange(0u, i))
+                CHECK(v.at(vals[i].first) == vals[i].second + 1);
+            for (auto i : test_irange(i, n))
+                CHECK(v.at(vals[i].first) == vals[i].second);
+        }
+        CHECK(d.happenings > 0);
+        IMMER_TRACE_E(d.happenings);
+    }
+
+    SECTION("update collisisions move")
+    {
+        auto vals = make_values_with_collisions(n);
+        auto v    = dadaist_conflictor_map_t{};
+        auto d    = dadaism{};
+        for (auto i = 0u; i < n; ++i)
+            v = std::move(v).insert(vals[i]);
+        for (auto i = 0u; i < v.size();) {
+            try {
+                auto s = d.next();
+                v      = std::move(v).update(vals[i].first,
+                                        [](auto x) { return x + 1; });
                 ++i;
             } catch (dada_error) {}
             for (auto i : test_irange(0u, i))

--- a/test/map_transient/B3.cpp
+++ b/test/map_transient/B3.cpp
@@ -1,0 +1,28 @@
+//
+// immer: immutable data structures for C++
+// Copyright (C) 2016, 2017, 2018 Juan Pedro Bolivar Puente
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include <immer/map.hpp>
+#include <immer/map_transient.hpp>
+
+template <typename K,
+          typename T,
+          typename Hash = std::hash<K>,
+          typename Eq   = std::equal_to<K>>
+using test_map_t = immer::map<K, T, Hash, Eq, immer::default_memory_policy, 3u>;
+
+template <typename K,
+          typename T,
+          typename Hash = std::hash<K>,
+          typename Eq   = std::equal_to<K>>
+using test_map_transient_t =
+    immer::map_transient<K, T, Hash, Eq, immer::default_memory_policy, 3u>;
+
+#define MAP_T test_map_t
+#define MAP_TRANSIENT_T test_map_transient_t
+
+#include "generic.ipp"

--- a/test/map_transient/B6.cpp
+++ b/test/map_transient/B6.cpp
@@ -1,0 +1,28 @@
+//
+// immer: immutable data structures for C++
+// Copyright (C) 2016, 2017, 2018 Juan Pedro Bolivar Puente
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include <immer/map.hpp>
+#include <immer/map_transient.hpp>
+
+template <typename K,
+          typename T,
+          typename Hash = std::hash<K>,
+          typename Eq   = std::equal_to<K>>
+using test_map_t = immer::map<K, T, Hash, Eq, immer::default_memory_policy, 6u>;
+
+template <typename K,
+          typename T,
+          typename Hash = std::hash<K>,
+          typename Eq   = std::equal_to<K>>
+using test_map_transient_t =
+    immer::map_transient<K, T, Hash, Eq, immer::default_memory_policy, 6u>;
+
+#define MAP_T test_map_t
+#define MAP_TRANSIENT_T test_map_transient_t
+
+#include "generic.ipp"

--- a/test/map_transient/default.cpp
+++ b/test/map_transient/default.cpp
@@ -1,0 +1,15 @@
+//
+// immer: immutable data structures for C++
+// Copyright (C) 2016, 2017, 2018 Juan Pedro Bolivar Puente
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include <immer/map.hpp>
+#include <immer/map_transient.hpp>
+
+#define MAP_T ::immer::map
+#define MAP_TRANSIENT_T ::immer::map_transient
+
+#include "generic.ipp"

--- a/test/map_transient/gc.cpp
+++ b/test/map_transient/gc.cpp
@@ -1,0 +1,36 @@
+//
+// immer: immutable data structures for C++
+// Copyright (C) 2016, 2017, 2018 Juan Pedro Bolivar Puente
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include <immer/heap/gc_heap.hpp>
+#include <immer/map.hpp>
+#include <immer/map_transient.hpp>
+#include <immer/refcount/no_refcount_policy.hpp>
+
+using gc_memory = immer::memory_policy<immer::heap_policy<immer::gc_heap>,
+                                       immer::no_refcount_policy,
+                                       immer::default_lock_policy,
+                                       immer::gc_transience_policy,
+                                       false>;
+
+template <typename K,
+          typename T,
+          typename Hash = std::hash<K>,
+          typename Eq   = std::equal_to<K>>
+using test_map_t = immer::map<K, T, Hash, Eq, gc_memory, 3u>;
+
+template <typename K,
+          typename T,
+          typename Hash = std::hash<K>,
+          typename Eq   = std::equal_to<K>>
+using test_map_transient_t =
+    immer::map_transient<K, T, Hash, Eq, gc_memory, 3u>;
+
+#define MAP_T test_map_t
+#define MAP_TRANSIENT_T test_map_transient_t
+
+#include "generic.ipp"

--- a/test/map_transient/generic.ipp
+++ b/test/map_transient/generic.ipp
@@ -1,0 +1,25 @@
+//
+// immer: immutable data structures for C++
+// Copyright (C) 2016, 2017, 2018 Juan Pedro Bolivar Puente
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include <catch.hpp>
+
+#ifndef MAP_T
+#error "define the map template to use in MAP_T"
+#endif
+
+#ifndef MAP_TRANSIENT_T
+#error "define the map template to use in MAP_TRANSIENT_T"
+#endif
+
+TEST_CASE("instantiate")
+{
+    auto t = MAP_TRANSIENT_T<std::string, int>{};
+    auto m = MAP_T<std::string, int>{};
+    CHECK(t.persistent() == m);
+    CHECK(t.persistent() == m.transient().persistent());
+}

--- a/test/map_transient/generic.ipp
+++ b/test/map_transient/generic.ipp
@@ -23,3 +23,63 @@ TEST_CASE("instantiate")
     CHECK(t.persistent() == m);
     CHECK(t.persistent() == m.transient().persistent());
 }
+
+TEST_CASE("access")
+{
+    auto m = MAP_T<std::string, int>{{"foo", 12}, {"bar", 42}};
+    auto t = m.transient();
+    CHECK(t.size() == 2);
+    CHECK(t.count("foo") == 1);
+    CHECK(t["foo"] == 12);
+    CHECK(t.at("foo") == 12);
+    CHECK(t.find("foo") == m.find("foo"));
+    CHECK(std::accumulate(t.begin(), t.end(), 0, [](auto acc, auto&& x) {
+              return acc + x.second;
+          }) == 54);
+}
+
+TEST_CASE("insert")
+{
+    auto t = MAP_TRANSIENT_T<std::string, int>{};
+
+    t.insert({"foo", 42});
+    CHECK(t["foo"] == 42);
+    CHECK(t.size() == 1);
+
+    t.insert({"bar", 13});
+    CHECK(t["bar"] == 13);
+    CHECK(t.size() == 2);
+
+    t.insert({"foo", 6});
+    CHECK(t["foo"] == 6);
+    CHECK(t.size() == 2);
+}
+
+TEST_CASE("set")
+{
+    auto t = MAP_TRANSIENT_T<std::string, int>{};
+
+    t.set("foo", 42);
+    CHECK(t["foo"] == 42);
+    CHECK(t.size() == 1);
+
+    t.set("bar", 13);
+    CHECK(t["bar"] == 13);
+    CHECK(t.size() == 2);
+
+    t.set("foo", 6);
+    CHECK(t["foo"] == 6);
+    CHECK(t.size() == 2);
+}
+
+TEST_CASE("erase")
+{
+    auto t = MAP_T<std::string, int>{{"foo", 12}, {"bar", 42}}.transient();
+
+    t.erase("foo");
+    CHECK(t.find("foo") == nullptr);
+    CHECK(t.count("foo") == 0);
+    CHECK(t.find("bar") != nullptr);
+    CHECK(t.count("bar") == 1);
+    CHECK(t.size() == 1);
+}

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -144,6 +144,17 @@ TEST_CASE("instantiation")
     }
 }
 
+TEST_CASE("initializer list and range constructors")
+{
+    auto v0 = std::unordered_set<std::string>{{"foo", "bar", "baz", "zab"}};
+    auto v1 = SET_T<std::string>{{"foo", "bar", "baz", "zab"}};
+    auto v2 = SET_T<std::string>{v0.begin(), v0.end()};
+    CHECK(v1.size() == 4);
+    CHECK(v1.count(std::string{"foo"}) == 1);
+    CHECK(v1.at(std::string{"bar"}) == 13);
+    CHECK(v1 == v2);
+}
+
 TEST_CASE("basic insertion")
 {
     auto v1 = SET_T<unsigned>{};

--- a/test/set_transient/B3.cpp
+++ b/test/set_transient/B3.cpp
@@ -1,0 +1,26 @@
+//
+// immer: immutable data structures for C++
+// Copyright (C) 2016, 2017, 2018 Juan Pedro Bolivar Puente
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include <immer/set.hpp>
+#include <immer/set_transient.hpp>
+
+template <typename T,
+          typename Hash = std::hash<T>,
+          typename Eq   = std::equal_to<T>>
+using test_set_t = immer::set<T, Hash, Eq, immer::default_memory_policy, 3u>;
+
+template <typename T,
+          typename Hash = std::hash<T>,
+          typename Eq   = std::equal_to<T>>
+using test_set_transient_t =
+    immer::set_transient<T, Hash, Eq, immer::default_memory_policy, 3u>;
+
+#define SET_T test_set_t
+#define SET_TRANSIENT_T test_set_transient_t
+
+#include "generic.ipp"

--- a/test/set_transient/B6.cpp
+++ b/test/set_transient/B6.cpp
@@ -1,0 +1,26 @@
+//
+// immer: immutable data structures for C++
+// Copyright (C) 2016, 2017, 2018 Juan Pedro Bolivar Puente
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include <immer/set.hpp>
+#include <immer/set_transient.hpp>
+
+template <typename T,
+          typename Hash = std::hash<T>,
+          typename Eq   = std::equal_to<T>>
+using test_set_t = immer::set<T, Hash, Eq, immer::default_memory_policy, 6u>;
+
+template <typename T,
+          typename Hash = std::hash<T>,
+          typename Eq   = std::equal_to<T>>
+using test_set_transient_t =
+    immer::set_transient<T, Hash, Eq, immer::default_memory_policy, 6u>;
+
+#define SET_T test_set_t
+#define SET_TRANSIENT_T test_set_transient_t
+
+#include "generic.ipp"

--- a/test/set_transient/default.cpp
+++ b/test/set_transient/default.cpp
@@ -1,0 +1,15 @@
+//
+// immer: immutable data structures for C++
+// Copyright (C) 2016, 2017, 2018 Juan Pedro Bolivar Puente
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include <immer/set.hpp>
+#include <immer/set_transient.hpp>
+
+#define SET_T ::immer::set
+#define SET_TRANSIENT_T ::immer::set_transient
+
+#include "generic.ipp"

--- a/test/set_transient/gc.cpp
+++ b/test/set_transient/gc.cpp
@@ -1,0 +1,33 @@
+//
+// immer: immutable data structures for C++
+// Copyright (C) 2016, 2017, 2018 Juan Pedro Bolivar Puente
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include <immer/heap/gc_heap.hpp>
+#include <immer/refcount/no_refcount_policy.hpp>
+#include <immer/set.hpp>
+#include <immer/set_transient.hpp>
+
+using gc_memory = immer::memory_policy<immer::heap_policy<immer::gc_heap>,
+                                       immer::no_refcount_policy,
+                                       immer::default_lock_policy,
+                                       immer::gc_transience_policy,
+                                       false>;
+
+template <typename T,
+          typename Hash = std::hash<T>,
+          typename Eq   = std::equal_to<T>>
+using test_set_t = immer::set<T, Hash, Eq, gc_memory, 3u>;
+
+template <typename T,
+          typename Hash = std::hash<T>,
+          typename Eq   = std::equal_to<T>>
+using test_set_transient_t = immer::set_transient<T, Hash, Eq, gc_memory, 3u>;
+
+#define SET_T test_set_t
+#define SET_TRANSIENT_T test_set_transient_t
+
+#include "generic.ipp"

--- a/test/set_transient/generic.ipp
+++ b/test/set_transient/generic.ipp
@@ -23,3 +23,42 @@ TEST_CASE("instantiate")
     CHECK(t.persistent() == m);
     CHECK(t.persistent() == m.transient().persistent());
 }
+
+TEST_CASE("access")
+{
+    auto m = SET_T<int>{12, 42};
+    auto t = m.transient();
+    CHECK(t.size() == 2);
+    CHECK(t.count(42) == 1);
+    CHECK(*t.find(12) == 12);
+    CHECK(std::accumulate(t.begin(), t.end(), 0) == 54);
+}
+
+TEST_CASE("insert")
+{
+    auto t = SET_TRANSIENT_T<int>{};
+
+    t.insert(42);
+    CHECK(*t.find(42) == 42);
+    CHECK(t.size() == 1);
+
+    t.insert(13);
+    CHECK(*t.find(13) == 13);
+    CHECK(t.size() == 2);
+
+    t.insert(42);
+    CHECK(*t.find(42) == 42);
+    CHECK(t.size() == 2);
+}
+
+TEST_CASE("erase")
+{
+    auto t = SET_T<int>{12, 42}.transient();
+
+    t.erase(42);
+    CHECK(t.find(42) == nullptr);
+    CHECK(t.count(42) == 0);
+    CHECK(t.find(12) != nullptr);
+    CHECK(t.count(12) == 1);
+    CHECK(t.size() == 1);
+}

--- a/test/set_transient/generic.ipp
+++ b/test/set_transient/generic.ipp
@@ -1,0 +1,25 @@
+//
+// immer: immutable data structures for C++
+// Copyright (C) 2016, 2017, 2018 Juan Pedro Bolivar Puente
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include <catch.hpp>
+
+#ifndef SET_T
+#error "define the set template to use in SET_T"
+#endif
+
+#ifndef SET_TRANSIENT_T
+#error "define the set template to use in SET_TRANSIENT_T"
+#endif
+
+TEST_CASE("instantiate")
+{
+    auto t = SET_TRANSIENT_T<int>{};
+    auto m = SET_T<int>{};
+    CHECK(t.persistent() == m);
+    CHECK(t.persistent() == m.transient().persistent());
+}


### PR DESCRIPTION
This PR is the first step towards the full implementation of transients for all [HAMT](https://en.wikipedia.org/wiki/Hash_array_mapped_trie)-based data-structures: `map` and `set`. 

In this PR we do define the interface in two modes:
- Using the special types `map_transient` and `set_transient`, which define a mutable interface (similar to the case of `vector_transient` and alike). This is required to benefit from the optimizations brought about by transients when using a tracing garbage collector.
- Using `std::move(x)...` when performing an operation on an immutable map. This will incur in the same performance benefit as the former when using reference counting for garbage collection (default) and is the recommended way to benefit from it.

In this PR we define and test the interface. We also include the new interface as part of the existing benchmarks for HAMT insertion. The implementation is however naive, this is, it is based on the purely immutable counterpart, an provides no performance benefit. We will explore different alternatives for optimization in subsequent PRs.

Issue #82 

PING @omer-s @harryhk from Meta Inc. who is sponsoring this HAMT-transient implementation project!