### PR TITLE
Implement transients for map and set

### DIFF
--- a/benchmark/set/insert.ipp
+++ b/benchmark/set/insert.ipp
@@ -28,19 +28,15 @@ NONIUS_BENCHMARK("immer::set/GC", benchmark_insert<generator__, immer::set<t__, 
 #endif
 NONIUS_BENCHMARK("immer::set/UN", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,unsafe_memory,5>>())
 
-NONIUS_BENCHMARK("immer::set/5B", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,5>>())
-NONIUS_BENCHMARK("immer::set/4B", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,4>>())
-#ifndef DISABLE_GC_BENCHMARKS
-NONIUS_BENCHMARK("immer::set/GC", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,gc_memory,5>>())
-#endif
-NONIUS_BENCHMARK("immer::set/UN", benchmark_insert<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,unsafe_memory,5>>())
-
 NONIUS_BENCHMARK("immer::set/move/5B", benchmark_insert_move<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,5>>())
 NONIUS_BENCHMARK("immer::set/move/4B", benchmark_insert_move<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,def_memory,4>>())
 NONIUS_BENCHMARK("immer::set/move/UN", benchmark_insert_move<generator__, immer::set<t__, std::hash<t__>,std::equal_to<t__>,unsafe_memory,5>>())
 
 NONIUS_BENCHMARK("immer::set/tran/5B", benchmark_insert_mut_std<generator__, immer::set_transient<t__, std::hash<t__>,std::equal_to<t__>,def_memory,5>>())
 NONIUS_BENCHMARK("immer::set/tran/4B", benchmark_insert_mut_std<generator__, immer::set_transient<t__, std::hash<t__>,std::equal_to<t__>,def_memory,4>>())
+#ifndef DISABLE_GC_BENCHMARKS
+NONIUS_BENCHMARK("immer::set/tran/GC", benchmark_insert_mut_std<generator__, immer::set_transient<t__, std::hash<t__>,std::equal_to<t__>,gc_memory,5>>())
+#endif
 NONIUS_BENCHMARK("immer::set/tran/UN", benchmark_insert_mut_std<generator__, immer::set_transient<t__, std::hash<t__>,std::equal_to<t__>,unsafe_memory,5>>())
 
 // clang-format on

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -416,10 +416,15 @@ struct champ
             auto fst = node->collisions();
             auto lst = fst + node->collision_count();
             for (; fst != lst; ++fst)
-                if (Equal{}(*fst, v))
-                    return {
-                        node_t::copy_collision_replace(node, fst, std::move(v)),
-                        false};
+                if (Equal{}(*fst, v)) {
+                    if (node->can_mutate(e)) {
+                        *fst = std::move(v);
+                    } else {
+                        return {node_t::copy_collision_replace(
+                                    node, fst, std::move(v)),
+                                false};
+                    }
+                }
             return {node_t::copy_collision_insert(node, std::move(v)), true};
         } else {
             auto idx = (hash & (mask<B> << shift)) >> shift;

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -27,6 +27,8 @@ struct champ
     static constexpr auto bits = B;
 
     using node_t   = node<T, Hash, Equal, MemoryPolicy, B>;
+    using edit_t   = typename MemoryPolicy::transience_t::edit;
+    using owner_t  = typename MemoryPolicy::transience_t::owner;
     using bitmap_t = typename get_bitmap_type<B>::type;
 
     static_assert(branches<B> <= sizeof(bitmap_t) * 8, "");
@@ -404,6 +406,72 @@ struct champ
         auto res      = do_add(root, std::move(v), hash, 0);
         auto new_size = size + (res.second ? 1 : 0);
         return {res.first, new_size};
+    }
+
+    std::pair<node_t*, bool>
+    do_add_mut(edit_t e, node_t* node, T v, hash_t hash, shift_t shift) const
+    {
+        assert(node);
+        if (shift == max_shift<B>) {
+            auto fst = node->collisions();
+            auto lst = fst + node->collision_count();
+            for (; fst != lst; ++fst)
+                if (Equal{}(*fst, v))
+                    return {
+                        node_t::copy_collision_replace(node, fst, std::move(v)),
+                        false};
+            return {node_t::copy_collision_insert(node, std::move(v)), true};
+        } else {
+            auto idx = (hash & (mask<B> << shift)) >> shift;
+            auto bit = bitmap_t{1u} << idx;
+            if (node->nodemap() & bit) {
+                auto offset = node->children_count(bit);
+                assert(node->children()[offset]);
+                auto result = do_add_mut(
+                    e, node->children()[offset], std::move(v), hash, shift + B);
+                IMMER_TRY {
+                    result.first =
+                        node_t::copy_inner_replace(node, offset, result.first);
+                    return result;
+                }
+                IMMER_CATCH (...) {
+                    node_t::delete_deep_shift(result.first, shift + B);
+                    IMMER_RETHROW;
+                }
+            } else if (node->datamap() & bit) {
+                auto offset = node->data_count(bit);
+                auto val    = node->values() + offset;
+                if (Equal{}(*val, v))
+                    return {node_t::copy_inner_replace_value(
+                                node, offset, std::move(v)),
+                            false};
+                else {
+                    auto child = node_t::make_merged(
+                        shift + B, std::move(v), hash, *val, Hash{}(*val));
+                    IMMER_TRY {
+                        return {node_t::copy_inner_replace_merged(
+                                    node, bit, offset, child),
+                                true};
+                    }
+                    IMMER_CATCH (...) {
+                        node_t::delete_deep_shift(child, shift + B);
+                        IMMER_RETHROW;
+                    }
+                }
+            } else {
+                return {
+                    node_t::copy_inner_insert_value(node, bit, std::move(v)),
+                    true};
+            }
+        }
+    }
+
+    void add_mut(edit_t e, T v)
+    {
+        auto hash = Hash{}(v);
+        auto res  = do_add_mut(e, root, std::move(v), hash, 0);
+        root      = res.first;
+        size += res.second ? 1 : 0;
     }
 
     template <typename Project,

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -696,6 +696,7 @@ struct node
     static void delete_values(values_t* p, count_t n)
     {
         assert(p);
+        destroy_n((T*) &p->d.buffer, n);
         deallocate_values(p, n);
     }
 
@@ -714,6 +715,7 @@ struct node
         assert(p);
         IMMER_ASSERT_TAGGED(p->kind() == kind_t::collision);
         auto n = p->collision_count();
+        destroy_n(p->collisions(), n);
         deallocate_collision(p, n);
     }
 
@@ -747,13 +749,11 @@ struct node
 
     static void deallocate_values(values_t* p, count_t n)
     {
-        destroy_n((T*) &p->d.buffer, n);
         heap::deallocate(node_t::sizeof_values_n(n), p);
     }
 
     static void deallocate_collision(node_t* p, count_t n)
     {
-        destroy_n(p->collisions(), n);
         heap::deallocate(node_t::sizeof_collision_n(n), p);
     }
 

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -35,7 +35,6 @@ struct node
     using transience  = typename memory::transience_t;
     using refs_t      = typename memory::refcount;
     using ownee_t     = typename transience::ownee;
-    using edit_t      = typename transience::edit;
     using value_t     = T;
     using bitmap_t    = typename get_bitmap_type<B>::type;
 

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -35,6 +35,7 @@ struct node
     using transience  = typename memory::transience_t;
     using refs_t      = typename memory::refcount;
     using ownee_t     = typename transience::ownee;
+    using edit_t      = typename transience::edit;
     using value_t     = T;
     using bitmap_t    = typename get_bitmap_type<B>::type;
 
@@ -55,7 +56,7 @@ struct node
         aligned_storage_for<T> buffer;
     };
 
-    using values_t = combine_standard_layout_t<values_data_t, refs_t>;
+    using values_t = combine_standard_layout_t<values_data_t, refs_t, ownee_t>;
 
     struct inner_t
     {
@@ -79,7 +80,7 @@ struct node
         data_t data;
     };
 
-    using impl_t = combine_standard_layout_t<impl_data_t, refs_t>;
+    using impl_t = combine_standard_layout_t<impl_data_t, refs_t, ownee_t>;
 
     impl_t impl;
 
@@ -202,6 +203,11 @@ struct node
         return get<ownee_t>(x->impl);
     }
     static ownee_t& ownee(node_t* x) { return get<ownee_t>(x->impl); }
+
+    bool can_mutate(edit_t e) const
+    {
+        return refs(this).unique() || ownee(this).can_mutate(e);
+    }
 
     static node_t* make_inner_n(count_t n)
     {

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -454,8 +454,7 @@ private:
 
     map&& insert_move(std::true_type, value_type value)
     {
-        // xxx: implement mutable version
-        impl_ = impl_.add(std::move(value));
+        impl_.add_mut({}, std::move(value));
         return std::move(*this);
     }
     map insert_move(std::false_type, value_type value)
@@ -465,8 +464,7 @@ private:
 
     map&& set_move(std::true_type, key_type k, mapped_type m)
     {
-        // xxx: implement mutable version
-        impl_ = impl_.add({std::move(k), std::move(m)});
+        impl_.add_mut({}, {std::move(k), std::move(m)});
         return std::move(*this);
     }
     map set_move(std::false_type, key_type k, mapped_type m)

--- a/immer/map_transient.hpp
+++ b/immer/map_transient.hpp
@@ -237,11 +237,7 @@ public:
      * replaces its association in the map.  It may allocate memory and its
      * complexity is *effectively* @f$ O(1) @f$.
      */
-    void insert(value_type value)
-    {
-        // xxx: implement mutable version
-        impl_ = impl_.add(std::move(value));
-    }
+    void insert(value_type value) { impl_.add_mut(*this, std::move(value)); }
 
     /*!
      * Inserts the association `(k, v)`.  If the key is already in the map, it
@@ -250,8 +246,7 @@ public:
      */
     void set(key_type k, mapped_type v)
     {
-        // xxx: implement mutable version
-        impl_ = impl_.add({std::move(k), std::move(v)});
+        impl_.add_mut(*this, {std::move(k), std::move(v)});
     }
 
     /*!

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -261,8 +261,7 @@ private:
 
     set&& insert_move(std::true_type, value_type value)
     {
-        // xxx: implement mutable version
-        impl_ = impl_.add(std::move(value));
+        impl_.add_mut({}, std::move(value));
         return std::move(*this);
     }
     set insert_move(std::false_type, value_type value)

--- a/immer/set_transient.hpp
+++ b/immer/set_transient.hpp
@@ -151,11 +151,7 @@ public:
      * there  It may allocate memory and its complexity is *effectively* @f$
      * O(1) @f$.
      */
-    void insert(T value)
-    {
-        // xxx: implement mutable version
-        impl_ = impl_.add(std::move(value));
-    }
+    void insert(T value) { impl_.add_mut(*this, std::move(value)); }
 
     /*!
      * Removes the `value` from the set, doing nothing if the value is not in


### PR DESCRIPTION
This PR adds basic transience for insertion into HAMT based data-structures.

Affected methods are:
* **`immer::map`**
  - `set() &&`
  - `insert() &&`
* **`immer::set`**
  - `insert() &&`
* **`immer::map_transient`** 
   - `set()`
   - `insert()`
* **`immer::set_transient`** 
  - `insert()`
  
In this optimization, when a node is reusable during insertion, it is mutated in place instead of adding creating a new node. For now, we can do this only when the resulting node is the same size as it was. For small maps and sets (< 16 elements), this does not have much of an effect. But as the map grows and grows, we can see the effect of this optimization really taking over. This is particularly notable when the value type stored in the map is small, so copying inner nodes and touching reference counts dominates the time spent when producing large collections. In this case, benchmarks show that performance can be up to an order magnitude faster for large vectors.

Some benchmarks run locally on my machine: [benchmark reports](https://public.sinusoid.es/misc/immer/reports/report_982aa1f_ce1_g%2B%2B_N%3A%2A%3A100%3A10%3A4_s20/)

PING @omer-s @harryhk 