### PR TITLE
HAMT transients: move mutable inner nodes when posible during insertion

### DIFF
--- a/immer/config.hpp
+++ b/immer/config.hpp
@@ -8,6 +8,10 @@
 
 #pragma once
 
+#if (__cplusplus >= 201703L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#define IMMER_HAS_CPP17 1
+#endif
+
 #if defined(__has_cpp_attribute)
 #if __has_cpp_attribute(nodiscard)
 #define IMMER_NODISCARD [[nodiscard]]

--- a/immer/detail/arrays/node.hpp
+++ b/immer/detail/arrays/node.hpp
@@ -61,7 +61,7 @@ struct node
 
     static void delete_n(node_t* p, size_t sz, size_t cap)
     {
-        destroy_n(p->data(), sz);
+        detail::destroy_n(p->data(), sz);
         heap::deallocate(sizeof_n(cap), p);
     }
 
@@ -98,7 +98,7 @@ struct node
     {
         auto p = make_n(n);
         IMMER_TRY {
-            uninitialized_copy(first, last, p->data());
+            detail::uninitialized_copy(first, last, p->data());
             return p;
         }
         IMMER_CATCH (...) {

--- a/immer/detail/arrays/with_capacity.hpp
+++ b/immer/detail/arrays/with_capacity.hpp
@@ -302,7 +302,7 @@ struct with_capacity
     {
         assert(sz <= size);
         if (ptr->can_mutate(e)) {
-            destroy_n(data() + size, size - sz);
+            detail::destroy_n(data() + size, size - sz);
             size = sz;
         } else {
             auto cap = recommend_down(sz, capacity);

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -359,7 +359,7 @@ struct node
             auto src   = values();
             ownee(nxt) = e;
             IMMER_TRY {
-                uninitialized_copy(src, src + nv, dst);
+                detail::uninitialized_copy(src, src + nv, dst);
             }
             IMMER_CATCH (...) {
                 deallocate_values(nxt, nv);
@@ -382,7 +382,7 @@ struct node
         IMMER_TRY {
             new (dstp) T{std::move(v)};
             IMMER_TRY {
-                uninitialized_copy(srcp, srcp + n, dstp + 1);
+                detail::uninitialized_copy(srcp, srcp + n, dstp + 1);
             }
             IMMER_CATCH (...) {
                 dstp->~T();
@@ -406,7 +406,7 @@ struct node
         IMMER_TRY {
             new (dstp) T{std::move(v)};
             IMMER_TRY {
-                uninitialized_move(srcp, srcp + n, dstp + 1);
+                detail::uninitialized_move(srcp, srcp + n, dstp + 1);
             }
             IMMER_CATCH (...) {
                 dstp->~T();
@@ -430,12 +430,12 @@ struct node
         auto srcp = src->collisions();
         auto dstp = dst->collisions();
         IMMER_TRY {
-            dstp = uninitialized_copy(srcp, v, dstp);
+            dstp = detail::uninitialized_copy(srcp, v, dstp);
             IMMER_TRY {
-                uninitialized_copy(v + 1, srcp + n, dstp);
+                detail::uninitialized_copy(v + 1, srcp + n, dstp);
             }
             IMMER_CATCH (...) {
-                destroy(dst->collisions(), dstp);
+                detail::destroy(dst->collisions(), dstp);
                 IMMER_RETHROW;
             }
         }
@@ -457,12 +457,12 @@ struct node
         IMMER_TRY {
             new (dstp) T{std::move(v)};
             IMMER_TRY {
-                dstp = uninitialized_copy(srcp, pos, dstp + 1);
+                dstp = detail::uninitialized_copy(srcp, pos, dstp + 1);
                 IMMER_TRY {
-                    uninitialized_copy(pos + 1, srcp + n, dstp);
+                    detail::uninitialized_copy(pos + 1, srcp + n, dstp);
                 }
                 IMMER_CATCH (...) {
-                    destroy(dst->collisions(), dstp);
+                    detail::destroy(dst->collisions(), dstp);
                     IMMER_RETHROW;
                 }
             }
@@ -526,13 +526,13 @@ struct node
         dst->impl.d.data.inner.datamap = src->datamap();
         dst->impl.d.data.inner.nodemap = src->nodemap();
         IMMER_TRY {
-            uninitialized_copy(
+            detail::uninitialized_copy(
                 src->values(), src->values() + nv, dst->values());
             IMMER_TRY {
                 dst->values()[offset] = std::move(v);
             }
             IMMER_CATCH (...) {
-                destroy_n(dst->values(), nv);
+                detail::destroy_n(dst->values(), nv);
                 IMMER_RETHROW;
             }
         }
@@ -562,15 +562,15 @@ struct node
         dst->impl.d.data.inner.nodemap = src->nodemap() | bit;
         if (nv > 1) {
             IMMER_TRY {
-                uninitialized_copy(
+                detail::uninitialized_copy(
                     src->values(), src->values() + voffset, dst->values());
                 IMMER_TRY {
-                    uninitialized_copy(src->values() + voffset + 1,
-                                       src->values() + nv,
-                                       dst->values() + voffset);
+                    detail::uninitialized_copy(src->values() + voffset + 1,
+                                               src->values() + nv,
+                                               dst->values() + voffset);
                 }
                 IMMER_CATCH (...) {
-                    destroy_n(dst->values(), voffset);
+                    detail::destroy_n(dst->values(), voffset);
                     IMMER_RETHROW;
                 }
             }
@@ -605,23 +605,23 @@ struct node
             auto mutate_values = can_mutate(dst->impl.d.data.inner.values, e);
             IMMER_TRY {
                 if (mutate_values)
-                    uninitialized_move(
+                    detail::uninitialized_move(
                         src->values(), src->values() + voffset, dst->values());
                 else
-                    uninitialized_copy(
+                    detail::uninitialized_copy(
                         src->values(), src->values() + voffset, dst->values());
                 IMMER_TRY {
                     if (mutate_values)
-                        uninitialized_move(src->values() + voffset + 1,
-                                           src->values() + nv,
-                                           dst->values() + voffset);
+                        detail::uninitialized_move(src->values() + voffset + 1,
+                                                   src->values() + nv,
+                                                   dst->values() + voffset);
                     else
-                        uninitialized_copy(src->values() + voffset + 1,
-                                           src->values() + nv,
-                                           dst->values() + voffset);
+                        detail::uninitialized_copy(src->values() + voffset + 1,
+                                                   src->values() + nv,
+                                                   dst->values() + voffset);
                 }
                 IMMER_CATCH (...) {
-                    destroy_n(dst->values(), voffset);
+                    detail::destroy_n(dst->values(), voffset);
                     IMMER_RETHROW;
                 }
             }
@@ -657,15 +657,15 @@ struct node
         dst->impl.d.data.inner.datamap = src->datamap() | bit;
         IMMER_TRY {
             if (nv)
-                uninitialized_copy(
+                detail::uninitialized_copy(
                     src->values(), src->values() + voffset, dst->values());
             IMMER_TRY {
                 new (dst->values() + voffset) T{std::move(value)};
                 IMMER_TRY {
                     if (nv)
-                        uninitialized_copy(src->values() + voffset,
-                                           src->values() + nv,
-                                           dst->values() + voffset + 1);
+                        detail::uninitialized_copy(src->values() + voffset,
+                                                   src->values() + nv,
+                                                   dst->values() + voffset + 1);
                 }
                 IMMER_CATCH (...) {
                     dst->values()[voffset].~T();
@@ -673,7 +673,7 @@ struct node
                 }
             }
             IMMER_CATCH (...) {
-                destroy_n(dst->values(), voffset);
+                detail::destroy_n(dst->values(), voffset);
                 IMMER_RETHROW;
             }
         }
@@ -704,15 +704,15 @@ struct node
         dst->impl.d.data.inner.nodemap = src->nodemap();
         if (nv > 1) {
             IMMER_TRY {
-                uninitialized_copy(
+                detail::uninitialized_copy(
                     src->values(), src->values() + voffset, dst->values());
                 IMMER_TRY {
-                    uninitialized_copy(src->values() + voffset + 1,
-                                       src->values() + nv,
-                                       dst->values() + voffset);
+                    detail::uninitialized_copy(src->values() + voffset + 1,
+                                               src->values() + nv,
+                                               dst->values() + voffset);
                 }
                 IMMER_CATCH (...) {
-                    destroy_n(dst->values(), voffset);
+                    detail::destroy_n(dst->values(), voffset);
                     IMMER_RETHROW;
                 }
             }
@@ -737,15 +737,15 @@ struct node
         dst->impl.d.data.inner.nodemap = src->nodemap();
         IMMER_TRY {
             if (nv)
-                uninitialized_copy(
+                detail::uninitialized_copy(
                     src->values(), src->values() + offset, dst->values());
             IMMER_TRY {
                 new (dst->values() + offset) T{std::move(v)};
                 IMMER_TRY {
                     if (nv)
-                        uninitialized_copy(src->values() + offset,
-                                           src->values() + nv,
-                                           dst->values() + offset + 1);
+                        detail::uninitialized_copy(src->values() + offset,
+                                                   src->values() + nv,
+                                                   dst->values() + offset + 1);
                 }
                 IMMER_CATCH (...) {
                     dst->values()[offset].~T();
@@ -753,7 +753,7 @@ struct node
                 }
             }
             IMMER_CATCH (...) {
-                destroy_n(dst->values(), offset);
+                detail::destroy_n(dst->values(), offset);
                 IMMER_RETHROW;
             }
         }
@@ -781,10 +781,10 @@ struct node
                 nv && can_mutate(dst->impl.d.data.inner.values, e);
             if (nv) {
                 if (mutate_values)
-                    uninitialized_move(
+                    detail::uninitialized_move(
                         src->values(), src->values() + offset, dst->values());
                 else
-                    uninitialized_copy(
+                    detail::uninitialized_copy(
                         src->values(), src->values() + offset, dst->values());
             }
             IMMER_TRY {
@@ -792,13 +792,15 @@ struct node
                 IMMER_TRY {
                     if (nv) {
                         if (mutate_values)
-                            uninitialized_move(src->values() + offset,
-                                               src->values() + nv,
-                                               dst->values() + offset + 1);
+                            detail::uninitialized_move(src->values() + offset,
+                                                       src->values() + nv,
+                                                       dst->values() + offset +
+                                                           1);
                         else
-                            uninitialized_copy(src->values() + offset,
-                                               src->values() + nv,
-                                               dst->values() + offset + 1);
+                            detail::uninitialized_copy(src->values() + offset,
+                                                       src->values() + nv,
+                                                       dst->values() + offset +
+                                                           1);
                     }
                 }
                 IMMER_CATCH (...) {
@@ -807,7 +809,7 @@ struct node
                 }
             }
             IMMER_CATCH (...) {
-                destroy_n(dst->values(), offset);
+                detail::destroy_n(dst->values(), offset);
                 IMMER_RETHROW;
             }
         }
@@ -905,7 +907,7 @@ struct node
     static void delete_values(values_t* p, count_t n)
     {
         assert(p);
-        destroy_n((T*) &p->d.buffer, n);
+        detail::destroy_n((T*) &p->d.buffer, n);
         deallocate_values(p, n);
     }
 
@@ -924,7 +926,7 @@ struct node
         assert(p);
         IMMER_ASSERT_TAGGED(p->kind() == kind_t::collision);
         auto n = p->collision_count();
-        destroy_n(p->collisions(), n);
+        detail::destroy_n(p->collisions(), n);
         deallocate_collision(p, n);
     }
 

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -359,7 +359,7 @@ struct node
             auto src   = values();
             ownee(nxt) = e;
             IMMER_TRY {
-                std::uninitialized_copy(src, src + nv, dst);
+                uninitialized_copy(src, src + nv, dst);
             }
             IMMER_CATCH (...) {
                 deallocate_values(nxt, nv);
@@ -382,7 +382,7 @@ struct node
         IMMER_TRY {
             new (dstp) T{std::move(v)};
             IMMER_TRY {
-                std::uninitialized_copy(srcp, srcp + n, dstp + 1);
+                uninitialized_copy(srcp, srcp + n, dstp + 1);
             }
             IMMER_CATCH (...) {
                 dstp->~T();
@@ -406,7 +406,7 @@ struct node
         IMMER_TRY {
             new (dstp) T{std::move(v)};
             IMMER_TRY {
-                detail::uninitialized_move(srcp, srcp + n, dstp + 1);
+                uninitialized_move(srcp, srcp + n, dstp + 1);
             }
             IMMER_CATCH (...) {
                 dstp->~T();
@@ -430,9 +430,9 @@ struct node
         auto srcp = src->collisions();
         auto dstp = dst->collisions();
         IMMER_TRY {
-            dstp = std::uninitialized_copy(srcp, v, dstp);
+            dstp = uninitialized_copy(srcp, v, dstp);
             IMMER_TRY {
-                std::uninitialized_copy(v + 1, srcp + n, dstp);
+                uninitialized_copy(v + 1, srcp + n, dstp);
             }
             IMMER_CATCH (...) {
                 destroy(dst->collisions(), dstp);
@@ -457,9 +457,9 @@ struct node
         IMMER_TRY {
             new (dstp) T{std::move(v)};
             IMMER_TRY {
-                dstp = std::uninitialized_copy(srcp, pos, dstp + 1);
+                dstp = uninitialized_copy(srcp, pos, dstp + 1);
                 IMMER_TRY {
-                    std::uninitialized_copy(pos + 1, srcp + n, dstp);
+                    uninitialized_copy(pos + 1, srcp + n, dstp);
                 }
                 IMMER_CATCH (...) {
                     destroy(dst->collisions(), dstp);
@@ -488,7 +488,7 @@ struct node
         auto dstp = dst->children();
         dst->impl.d.data.inner.datamap = src->datamap();
         dst->impl.d.data.inner.nodemap = src->nodemap();
-        std::uninitialized_copy(srcp, srcp + n, dstp);
+        std::copy(srcp, srcp + n, dstp);
         inc_nodes(srcp, n);
         srcp[offset]->dec_unsafe();
         dstp[offset] = child;
@@ -526,7 +526,7 @@ struct node
         dst->impl.d.data.inner.datamap = src->datamap();
         dst->impl.d.data.inner.nodemap = src->nodemap();
         IMMER_TRY {
-            std::uninitialized_copy(
+            uninitialized_copy(
                 src->values(), src->values() + nv, dst->values());
             IMMER_TRY {
                 dst->values()[offset] = std::move(v);
@@ -541,8 +541,7 @@ struct node
             IMMER_RETHROW;
         }
         inc_nodes(src->children(), n);
-        std::uninitialized_copy(
-            src->children(), src->children() + n, dst->children());
+        std::copy(src->children(), src->children() + n, dst->children());
         return dst;
     }
 
@@ -563,12 +562,12 @@ struct node
         dst->impl.d.data.inner.nodemap = src->nodemap() | bit;
         if (nv > 1) {
             IMMER_TRY {
-                std::uninitialized_copy(
+                uninitialized_copy(
                     src->values(), src->values() + voffset, dst->values());
                 IMMER_TRY {
-                    std::uninitialized_copy(src->values() + voffset + 1,
-                                            src->values() + nv,
-                                            dst->values() + voffset);
+                    uninitialized_copy(src->values() + voffset + 1,
+                                       src->values() + nv,
+                                       dst->values() + voffset);
                 }
                 IMMER_CATCH (...) {
                     destroy_n(dst->values(), voffset);
@@ -581,11 +580,10 @@ struct node
             }
         }
         inc_nodes(src->children(), n);
-        std::uninitialized_copy(
-            src->children(), src->children() + noffset, dst->children());
-        std::uninitialized_copy(src->children() + noffset,
-                                src->children() + n,
-                                dst->children() + noffset + 1);
+        std::copy(src->children(), src->children() + noffset, dst->children());
+        std::copy(src->children() + noffset,
+                  src->children() + n,
+                  dst->children() + noffset + 1);
         dst->children()[noffset] = node;
         return dst;
     }
@@ -607,20 +605,20 @@ struct node
             auto mutate_values = can_mutate(dst->impl.d.data.inner.values, e);
             IMMER_TRY {
                 if (mutate_values)
-                    detail::uninitialized_move(
+                    uninitialized_move(
                         src->values(), src->values() + voffset, dst->values());
                 else
-                    std::uninitialized_copy(
+                    uninitialized_copy(
                         src->values(), src->values() + voffset, dst->values());
                 IMMER_TRY {
                     if (mutate_values)
-                        detail::uninitialized_move(src->values() + voffset + 1,
-                                                   src->values() + nv,
-                                                   dst->values() + voffset);
+                        uninitialized_move(src->values() + voffset + 1,
+                                           src->values() + nv,
+                                           dst->values() + voffset);
                     else
-                        std::uninitialized_copy(src->values() + voffset + 1,
-                                                src->values() + nv,
-                                                dst->values() + voffset);
+                        uninitialized_copy(src->values() + voffset + 1,
+                                           src->values() + nv,
+                                           dst->values() + voffset);
                 }
                 IMMER_CATCH (...) {
                     destroy_n(dst->values(), voffset);
@@ -633,11 +631,10 @@ struct node
             }
         }
         // inc_nodes(src->children(), n);
-        std::uninitialized_copy(
-            src->children(), src->children() + noffset, dst->children());
-        std::uninitialized_copy(src->children() + noffset,
-                                src->children() + n,
-                                dst->children() + noffset + 1);
+        std::copy(src->children(), src->children() + noffset, dst->children());
+        std::copy(src->children() + noffset,
+                  src->children() + n,
+                  dst->children() + noffset + 1);
         dst->children()[noffset] = node;
         delete_inner(src);
         return dst;
@@ -660,15 +657,15 @@ struct node
         dst->impl.d.data.inner.datamap = src->datamap() | bit;
         IMMER_TRY {
             if (nv)
-                std::uninitialized_copy(
+                uninitialized_copy(
                     src->values(), src->values() + voffset, dst->values());
             IMMER_TRY {
                 new (dst->values() + voffset) T{std::move(value)};
                 IMMER_TRY {
                     if (nv)
-                        std::uninitialized_copy(src->values() + voffset,
-                                                src->values() + nv,
-                                                dst->values() + voffset + 1);
+                        uninitialized_copy(src->values() + voffset,
+                                           src->values() + nv,
+                                           dst->values() + voffset + 1);
                 }
                 IMMER_CATCH (...) {
                     dst->values()[voffset].~T();
@@ -686,11 +683,10 @@ struct node
         }
         inc_nodes(src->children(), n);
         src->children()[noffset]->dec_unsafe();
-        std::uninitialized_copy(
-            src->children(), src->children() + noffset, dst->children());
-        std::uninitialized_copy(src->children() + noffset + 1,
-                                src->children() + n,
-                                dst->children() + noffset);
+        std::copy(src->children(), src->children() + noffset, dst->children());
+        std::copy(src->children() + noffset + 1,
+                  src->children() + n,
+                  dst->children() + noffset);
         return dst;
     }
 
@@ -708,12 +704,12 @@ struct node
         dst->impl.d.data.inner.nodemap = src->nodemap();
         if (nv > 1) {
             IMMER_TRY {
-                std::uninitialized_copy(
+                uninitialized_copy(
                     src->values(), src->values() + voffset, dst->values());
                 IMMER_TRY {
-                    std::uninitialized_copy(src->values() + voffset + 1,
-                                            src->values() + nv,
-                                            dst->values() + voffset);
+                    uninitialized_copy(src->values() + voffset + 1,
+                                       src->values() + nv,
+                                       dst->values() + voffset);
                 }
                 IMMER_CATCH (...) {
                     destroy_n(dst->values(), voffset);
@@ -726,8 +722,7 @@ struct node
             }
         }
         inc_nodes(src->children(), n);
-        std::uninitialized_copy(
-            src->children(), src->children() + n, dst->children());
+        std::copy(src->children(), src->children() + n, dst->children());
         return dst;
     }
 
@@ -742,15 +737,15 @@ struct node
         dst->impl.d.data.inner.nodemap = src->nodemap();
         IMMER_TRY {
             if (nv)
-                std::uninitialized_copy(
+                uninitialized_copy(
                     src->values(), src->values() + offset, dst->values());
             IMMER_TRY {
                 new (dst->values() + offset) T{std::move(v)};
                 IMMER_TRY {
                     if (nv)
-                        std::uninitialized_copy(src->values() + offset,
-                                                src->values() + nv,
-                                                dst->values() + offset + 1);
+                        uninitialized_copy(src->values() + offset,
+                                           src->values() + nv,
+                                           dst->values() + offset + 1);
                 }
                 IMMER_CATCH (...) {
                     dst->values()[offset].~T();
@@ -767,8 +762,7 @@ struct node
             IMMER_RETHROW;
         }
         inc_nodes(src->children(), n);
-        std::uninitialized_copy(
-            src->children(), src->children() + n, dst->children());
+        std::copy(src->children(), src->children() + n, dst->children());
         return dst;
     }
 
@@ -787,10 +781,10 @@ struct node
                 nv && can_mutate(dst->impl.d.data.inner.values, e);
             if (nv) {
                 if (mutate_values)
-                    detail::uninitialized_move(
+                    uninitialized_move(
                         src->values(), src->values() + offset, dst->values());
                 else
-                    std::uninitialized_copy(
+                    uninitialized_copy(
                         src->values(), src->values() + offset, dst->values());
             }
             IMMER_TRY {
@@ -798,14 +792,13 @@ struct node
                 IMMER_TRY {
                     if (nv) {
                         if (mutate_values)
-                            detail::uninitialized_move(src->values() + offset,
-                                                       src->values() + nv,
-                                                       dst->values() + offset +
-                                                           1);
+                            uninitialized_move(src->values() + offset,
+                                               src->values() + nv,
+                                               dst->values() + offset + 1);
                         else
-                            std::uninitialized_copy(src->values() + offset,
-                                                    src->values() + nv,
-                                                    dst->values() + offset + 1);
+                            uninitialized_copy(src->values() + offset,
+                                               src->values() + nv,
+                                               dst->values() + offset + 1);
                     }
                 }
                 IMMER_CATCH (...) {
@@ -822,8 +815,7 @@ struct node
             deallocate_inner(dst, n, nv + 1);
             IMMER_RETHROW;
         }
-        std::uninitialized_copy(
-            src->children(), src->children() + n, dst->children());
+        std::copy(src->children(), src->children() + n, dst->children());
         delete_inner(src);
         return dst;
     }

--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -598,7 +598,8 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(n);
         IMMER_TRY {
-            uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
+            detail::uninitialized_copy(
+                src->leaf(), src->leaf() + n, dst->leaf());
         }
         IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(n), dst);
@@ -612,7 +613,8 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
         IMMER_TRY {
-            uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
+            detail::uninitialized_copy(
+                src->leaf(), src->leaf() + n, dst->leaf());
         }
         IMMER_CATCH (...) {
             heap::deallocate(node_t::max_sizeof_leaf, dst);
@@ -627,7 +629,8 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(allocn);
         IMMER_TRY {
-            uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
+            detail::uninitialized_copy(
+                src->leaf(), src->leaf() + n, dst->leaf());
         }
         IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(allocn), dst);
@@ -642,14 +645,15 @@ struct node
         IMMER_ASSERT_TAGGED(src2->kind() == kind_t::leaf);
         auto dst = make_leaf_n(n1 + n2);
         IMMER_TRY {
-            uninitialized_copy(src1->leaf(), src1->leaf() + n1, dst->leaf());
+            detail::uninitialized_copy(
+                src1->leaf(), src1->leaf() + n1, dst->leaf());
         }
         IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(n1 + n2), dst);
             IMMER_RETHROW;
         }
         IMMER_TRY {
-            uninitialized_copy(
+            detail::uninitialized_copy(
                 src2->leaf(), src2->leaf() + n2, dst->leaf() + n1);
         }
         IMMER_CATCH (...) {
@@ -667,14 +671,15 @@ struct node
         IMMER_ASSERT_TAGGED(src2->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
         IMMER_TRY {
-            uninitialized_copy(src1->leaf(), src1->leaf() + n1, dst->leaf());
+            detail::uninitialized_copy(
+                src1->leaf(), src1->leaf() + n1, dst->leaf());
         }
         IMMER_CATCH (...) {
             heap::deallocate(max_sizeof_leaf, dst);
             IMMER_RETHROW;
         }
         IMMER_TRY {
-            uninitialized_copy(
+            detail::uninitialized_copy(
                 src2->leaf(), src2->leaf() + n2, dst->leaf() + n1);
         }
         IMMER_CATCH (...) {
@@ -690,7 +695,7 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
         IMMER_TRY {
-            uninitialized_copy(
+            detail::uninitialized_copy(
                 src->leaf() + idx, src->leaf() + last, dst->leaf());
         }
         IMMER_CATCH (...) {
@@ -705,7 +710,7 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(last - idx);
         IMMER_TRY {
-            uninitialized_copy(
+            detail::uninitialized_copy(
                 src->leaf() + idx, src->leaf() + last, dst->leaf());
         }
         IMMER_CATCH (...) {
@@ -723,7 +728,7 @@ struct node
             new (dst->leaf() + n) T{std::forward<U>(x)};
         }
         IMMER_CATCH (...) {
-            destroy_n(dst->leaf(), n);
+            detail::destroy_n(dst->leaf(), n);
             heap::deallocate(node_t::sizeof_leaf_n(n + 1), dst);
             IMMER_RETHROW;
         }
@@ -786,7 +791,7 @@ struct node
     static void delete_leaf(node_t* p, count_t n)
     {
         IMMER_ASSERT_TAGGED(p->kind() == kind_t::leaf);
-        destroy_n(p->leaf(), n);
+        detail::destroy_n(p->leaf(), n);
         heap::deallocate(ownee(p).owned() ? node_t::max_sizeof_leaf
                                           : node_t::sizeof_leaf_n(n),
                          p);

--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -511,7 +511,7 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto dst = make_inner_n(n);
         inc_nodes(src->inner(), n);
-        std::uninitialized_copy(src->inner(), src->inner() + n, dst->inner());
+        std::copy(src->inner(), src->inner() + n, dst->inner());
         return dst;
     }
 
@@ -536,7 +536,7 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::inner);
         auto p = src->inner();
         inc_nodes(p, n);
-        std::uninitialized_copy(p, p + n, dst->inner());
+        std::copy(p, p + n, dst->inner());
         return dst;
     }
 
@@ -598,7 +598,7 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(n);
         IMMER_TRY {
-            std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
+            uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
         }
         IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(n), dst);
@@ -612,7 +612,7 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
         IMMER_TRY {
-            std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
+            uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
         }
         IMMER_CATCH (...) {
             heap::deallocate(node_t::max_sizeof_leaf, dst);
@@ -627,7 +627,7 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(allocn);
         IMMER_TRY {
-            std::uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
+            uninitialized_copy(src->leaf(), src->leaf() + n, dst->leaf());
         }
         IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(allocn), dst);
@@ -642,15 +642,14 @@ struct node
         IMMER_ASSERT_TAGGED(src2->kind() == kind_t::leaf);
         auto dst = make_leaf_n(n1 + n2);
         IMMER_TRY {
-            std::uninitialized_copy(
-                src1->leaf(), src1->leaf() + n1, dst->leaf());
+            uninitialized_copy(src1->leaf(), src1->leaf() + n1, dst->leaf());
         }
         IMMER_CATCH (...) {
             heap::deallocate(node_t::sizeof_leaf_n(n1 + n2), dst);
             IMMER_RETHROW;
         }
         IMMER_TRY {
-            std::uninitialized_copy(
+            uninitialized_copy(
                 src2->leaf(), src2->leaf() + n2, dst->leaf() + n1);
         }
         IMMER_CATCH (...) {
@@ -668,15 +667,14 @@ struct node
         IMMER_ASSERT_TAGGED(src2->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
         IMMER_TRY {
-            std::uninitialized_copy(
-                src1->leaf(), src1->leaf() + n1, dst->leaf());
+            uninitialized_copy(src1->leaf(), src1->leaf() + n1, dst->leaf());
         }
         IMMER_CATCH (...) {
             heap::deallocate(max_sizeof_leaf, dst);
             IMMER_RETHROW;
         }
         IMMER_TRY {
-            std::uninitialized_copy(
+            uninitialized_copy(
                 src2->leaf(), src2->leaf() + n2, dst->leaf() + n1);
         }
         IMMER_CATCH (...) {
@@ -692,7 +690,7 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_e(e);
         IMMER_TRY {
-            std::uninitialized_copy(
+            uninitialized_copy(
                 src->leaf() + idx, src->leaf() + last, dst->leaf());
         }
         IMMER_CATCH (...) {
@@ -707,7 +705,7 @@ struct node
         IMMER_ASSERT_TAGGED(src->kind() == kind_t::leaf);
         auto dst = make_leaf_n(last - idx);
         IMMER_TRY {
-            std::uninitialized_copy(
+            uninitialized_copy(
                 src->leaf() + idx, src->leaf() + last, dst->leaf());
         }
         IMMER_CATCH (...) {

--- a/immer/detail/rbts/operations.hpp
+++ b/immer/detail/rbts/operations.hpp
@@ -1627,9 +1627,9 @@ struct concat_merger
                 auto data = to_->leaf();
                 auto to_copy =
                     std::min(from_count - from_offset, *curr_ - to_offset_);
-                std::copy(from_data + from_offset,
-                          from_data + from_offset + to_copy,
-                          data + to_offset_);
+                detail::uninitialized_copy(from_data + from_offset,
+                                           from_data + from_offset + to_copy,
+                                           data + to_offset_);
                 to_offset_ += to_copy;
                 from_offset += to_copy;
                 if (*curr_ == to_offset_) {
@@ -2124,13 +2124,15 @@ struct concat_merger_mut
                                   data + to_offset_);
                 } else {
                     if (!from_mutate)
-                        uninitialized_copy(from_data + from_offset,
-                                           from_data + from_offset + to_copy,
-                                           data + to_offset_);
+                        detail::uninitialized_copy(from_data + from_offset,
+                                                   from_data + from_offset +
+                                                       to_copy,
+                                                   data + to_offset_);
                     else
-                        uninitialized_move(from_data + from_offset,
-                                           from_data + from_offset + to_copy,
-                                           data + to_offset_);
+                        detail::uninitialized_move(from_data + from_offset,
+                                                   from_data + from_offset +
+                                                       to_copy,
+                                                   data + to_offset_);
                 }
                 to_offset_ += to_copy;
                 from_offset += to_copy;

--- a/immer/detail/rbts/operations.hpp
+++ b/immer/detail/rbts/operations.hpp
@@ -1183,8 +1183,8 @@ struct slice_right_visitor : visitor_base<slice_right_visitor<NodeT, Collapse>>
         auto old_tail_size = pos.count();
         auto new_tail_size = pos.index(last) + 1;
         auto new_tail      = new_tail_size == old_tail_size
-                            ? pos.node()->inc()
-                            : node_t::copy_leaf(pos.node(), new_tail_size);
+                                 ? pos.node()->inc()
+                                 : node_t::copy_leaf(pos.node(), new_tail_size);
         return std::make_tuple(0, nullptr, new_tail_size, new_tail);
     }
 };
@@ -1263,10 +1263,10 @@ struct slice_left_mut_visitor
             return r;
         } else {
             using std::get;
-            auto newn = mutate ? (node->ensure_mutable_relaxed(e), node)
-                               : node_t::make_inner_r_e(e);
-            auto newr           = newn->relaxed();
-            auto newcount       = count - idx;
+            auto newn     = mutate ? (node->ensure_mutable_relaxed(e), node)
+                                   : node_t::make_inner_r_e(e);
+            auto newr     = newn->relaxed();
+            auto newcount = count - idx;
             auto new_child_size = child_size - child_dropped_size;
             IMMER_TRY {
                 auto subs =
@@ -1277,9 +1277,9 @@ struct slice_left_mut_visitor
                     pos.each_left(dec_visitor{}, idx);
                 pos.copy_sizes(
                     idx + 1, newcount - 1, new_child_size, newr->d.sizes + 1);
-                std::uninitialized_copy(node->inner() + idx + 1,
-                                        node->inner() + count,
-                                        newn->inner() + 1);
+                std::copy(node->inner() + idx + 1,
+                          node->inner() + count,
+                          newn->inner() + 1);
                 newn->inner()[0] = get<1>(subs);
                 newr->d.sizes[0] = new_child_size;
                 newr->d.count    = newcount;
@@ -1348,9 +1348,9 @@ struct slice_left_mut_visitor
                     idx + 1, newcount - 1, newr->d.sizes[0], newr->d.sizes + 1);
                 newr->d.count    = newcount;
                 newn->inner()[0] = get<1>(subs);
-                std::uninitialized_copy(node->inner() + idx + 1,
-                                        node->inner() + count,
-                                        newn->inner() + 1);
+                std::copy(node->inner() + idx + 1,
+                          node->inner() + count,
+                          newn->inner() + 1);
                 if (!mutate) {
                     node_t::inc_nodes(newn->inner() + 1, newcount - 1);
                     if (Mutating)
@@ -1439,9 +1439,9 @@ struct slice_left_visitor : visitor_base<slice_left_visitor<NodeT, Collapse>>
                 assert(newr->d.sizes[newr->d.count - 1] ==
                        pos.size() - dropped_size);
                 newn->inner()[0] = get<1>(subs);
-                std::uninitialized_copy(n->inner() + idx + 1,
-                                        n->inner() + count,
-                                        newn->inner() + 1);
+                std::copy(n->inner() + idx + 1,
+                          n->inner() + count,
+                          newn->inner() + 1);
                 node_t::inc_nodes(newn->inner() + 1, newr->d.count - 1);
                 return std::make_tuple(pos.shift(), newn);
             }
@@ -1627,9 +1627,9 @@ struct concat_merger
                 auto data = to_->leaf();
                 auto to_copy =
                     std::min(from_count - from_offset, *curr_ - to_offset_);
-                std::uninitialized_copy(from_data + from_offset,
-                                        from_data + from_offset + to_copy,
-                                        data + to_offset_);
+                std::copy(from_data + from_offset,
+                          from_data + from_offset + to_copy,
+                          data + to_offset_);
                 to_offset_ += to_copy;
                 from_offset += to_copy;
                 if (*curr_ == to_offset_) {
@@ -1662,9 +1662,9 @@ struct concat_merger
                 auto data = to_->inner();
                 auto to_copy =
                     std::min(from_count - from_offset, *curr_ - to_offset_);
-                std::uninitialized_copy(from_data + from_offset,
-                                        from_data + from_offset + to_copy,
-                                        data + to_offset_);
+                std::copy(from_data + from_offset,
+                          from_data + from_offset + to_copy,
+                          data + to_offset_);
                 node_t::inc_nodes(from_data + from_offset, to_copy);
                 auto sizes = to_->relaxed()->d.sizes;
                 p.copy_sizes(
@@ -2124,15 +2124,13 @@ struct concat_merger_mut
                                   data + to_offset_);
                 } else {
                     if (!from_mutate)
-                        std::uninitialized_copy(from_data + from_offset,
-                                                from_data + from_offset +
-                                                    to_copy,
-                                                data + to_offset_);
+                        uninitialized_copy(from_data + from_offset,
+                                           from_data + from_offset + to_copy,
+                                           data + to_offset_);
                     else
-                        detail::uninitialized_move(from_data + from_offset,
-                                                   from_data + from_offset +
-                                                       to_copy,
-                                                   data + to_offset_);
+                        uninitialized_move(from_data + from_offset,
+                                           from_data + from_offset + to_copy,
+                                           data + to_offset_);
                 }
                 to_offset_ += to_copy;
                 from_offset += to_copy;

--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -793,17 +793,17 @@ struct rrbtree
                 return;
             } else if (tail_size + r.size <= branches<BL>) {
                 l.ensure_mutable_tail(el, tail_size);
-                std::uninitialized_copy(r.tail->leaf(),
-                                        r.tail->leaf() + r.size,
-                                        l.tail->leaf() + tail_size);
+                uninitialized_copy(r.tail->leaf(),
+                                   r.tail->leaf() + r.size,
+                                   l.tail->leaf() + tail_size);
                 l.size += r.size;
                 return;
             } else {
                 auto remaining = branches<BL> - tail_size;
                 l.ensure_mutable_tail(el, tail_size);
-                std::uninitialized_copy(r.tail->leaf(),
-                                        r.tail->leaf() + remaining,
-                                        l.tail->leaf() + tail_size);
+                uninitialized_copy(r.tail->leaf(),
+                                   r.tail->leaf() + remaining,
+                                   l.tail->leaf() + tail_size);
                 IMMER_TRY {
                     auto new_tail =
                         node_t::copy_leaf_e(el, r.tail, remaining, r.size);
@@ -1062,26 +1062,26 @@ struct rrbtree
             } else if (tail_size + r.size <= branches<BL>) {
                 l.ensure_mutable_tail(el, tail_size);
                 if (r.tail->can_mutate(er))
-                    detail::uninitialized_move(r.tail->leaf(),
-                                               r.tail->leaf() + r.size,
-                                               l.tail->leaf() + tail_size);
+                    uninitialized_move(r.tail->leaf(),
+                                       r.tail->leaf() + r.size,
+                                       l.tail->leaf() + tail_size);
                 else
-                    std::uninitialized_copy(r.tail->leaf(),
-                                            r.tail->leaf() + r.size,
-                                            l.tail->leaf() + tail_size);
+                    uninitialized_copy(r.tail->leaf(),
+                                       r.tail->leaf() + r.size,
+                                       l.tail->leaf() + tail_size);
                 l.size += r.size;
                 return;
             } else {
                 auto remaining = branches<BL> - tail_size;
                 l.ensure_mutable_tail(el, tail_size);
                 if (r.tail->can_mutate(er))
-                    detail::uninitialized_move(r.tail->leaf(),
-                                               r.tail->leaf() + remaining,
-                                               l.tail->leaf() + tail_size);
+                    uninitialized_move(r.tail->leaf(),
+                                       r.tail->leaf() + remaining,
+                                       l.tail->leaf() + tail_size);
                 else
-                    std::uninitialized_copy(r.tail->leaf(),
-                                            r.tail->leaf() + remaining,
-                                            l.tail->leaf() + tail_size);
+                    uninitialized_copy(r.tail->leaf(),
+                                       r.tail->leaf() + remaining,
+                                       l.tail->leaf() + tail_size);
                 IMMER_TRY {
                     auto new_tail =
                         node_t::copy_leaf_e(el, r.tail, remaining, r.size);

--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -574,7 +574,7 @@ struct rrbtree
             auto ts    = size - tail_off;
             auto newts = new_size - tail_off;
             if (tail->can_mutate(e)) {
-                destroy_n(tail->leaf() + newts, ts - newts);
+                detail::destroy_n(tail->leaf() + newts, ts - newts);
             } else {
                 auto new_tail = node_t::copy_leaf_e(e, tail, newts);
                 dec_leaf(tail, ts);
@@ -793,17 +793,17 @@ struct rrbtree
                 return;
             } else if (tail_size + r.size <= branches<BL>) {
                 l.ensure_mutable_tail(el, tail_size);
-                uninitialized_copy(r.tail->leaf(),
-                                   r.tail->leaf() + r.size,
-                                   l.tail->leaf() + tail_size);
+                detail::uninitialized_copy(r.tail->leaf(),
+                                           r.tail->leaf() + r.size,
+                                           l.tail->leaf() + tail_size);
                 l.size += r.size;
                 return;
             } else {
                 auto remaining = branches<BL> - tail_size;
                 l.ensure_mutable_tail(el, tail_size);
-                uninitialized_copy(r.tail->leaf(),
-                                   r.tail->leaf() + remaining,
-                                   l.tail->leaf() + tail_size);
+                detail::uninitialized_copy(r.tail->leaf(),
+                                           r.tail->leaf() + remaining,
+                                           l.tail->leaf() + tail_size);
                 IMMER_TRY {
                     auto new_tail =
                         node_t::copy_leaf_e(el, r.tail, remaining, r.size);
@@ -819,7 +819,7 @@ struct rrbtree
                     }
                 }
                 IMMER_CATCH (...) {
-                    destroy_n(r.tail->leaf() + tail_size, remaining);
+                    detail::destroy_n(r.tail->leaf() + tail_size, remaining);
                     IMMER_RETHROW;
                 }
             }
@@ -1062,26 +1062,26 @@ struct rrbtree
             } else if (tail_size + r.size <= branches<BL>) {
                 l.ensure_mutable_tail(el, tail_size);
                 if (r.tail->can_mutate(er))
-                    uninitialized_move(r.tail->leaf(),
-                                       r.tail->leaf() + r.size,
-                                       l.tail->leaf() + tail_size);
+                    detail::uninitialized_move(r.tail->leaf(),
+                                               r.tail->leaf() + r.size,
+                                               l.tail->leaf() + tail_size);
                 else
-                    uninitialized_copy(r.tail->leaf(),
-                                       r.tail->leaf() + r.size,
-                                       l.tail->leaf() + tail_size);
+                    detail::uninitialized_copy(r.tail->leaf(),
+                                               r.tail->leaf() + r.size,
+                                               l.tail->leaf() + tail_size);
                 l.size += r.size;
                 return;
             } else {
                 auto remaining = branches<BL> - tail_size;
                 l.ensure_mutable_tail(el, tail_size);
                 if (r.tail->can_mutate(er))
-                    uninitialized_move(r.tail->leaf(),
-                                       r.tail->leaf() + remaining,
-                                       l.tail->leaf() + tail_size);
+                    detail::uninitialized_move(r.tail->leaf(),
+                                               r.tail->leaf() + remaining,
+                                               l.tail->leaf() + tail_size);
                 else
-                    uninitialized_copy(r.tail->leaf(),
-                                       r.tail->leaf() + remaining,
-                                       l.tail->leaf() + tail_size);
+                    detail::uninitialized_copy(r.tail->leaf(),
+                                               r.tail->leaf() + remaining,
+                                               l.tail->leaf() + tail_size);
                 IMMER_TRY {
                     auto new_tail =
                         node_t::copy_leaf_e(el, r.tail, remaining, r.size);
@@ -1097,7 +1097,7 @@ struct rrbtree
                     }
                 }
                 IMMER_CATCH (...) {
-                    destroy_n(r.tail->leaf() + tail_size, remaining);
+                    detail::destroy_n(r.tail->leaf() + tail_size, remaining);
                     IMMER_RETHROW;
                 }
             }

--- a/immer/detail/util.hpp
+++ b/immer/detail/util.hpp
@@ -39,11 +39,6 @@ T&& auto_const_cast(const T&& x)
     return const_cast<T&&>(std::move(x));
 }
 
-#if IMMER_HAS_CPP17
-using std::destroy;
-using std::destroy_n;
-using std::uninitialized_move;
-#else
 template <class T>
 inline auto destroy_at(T* p)
     -> std::enable_if_t<std::is_trivially_destructible<T>::value>
@@ -123,7 +118,6 @@ auto uninitialized_move(Iter1 first, Iter1 last, Iter2 out)
         throw;
     }
 }
-#endif // IMMER_HAS_CPP17
 
 template <typename Heap, typename T, typename... Args>
 T* make(Args&&... args)

--- a/immer/detail/util.hpp
+++ b/immer/detail/util.hpp
@@ -110,7 +110,7 @@ auto uninitialized_move(Iter1 first, Iter1 last, Iter2 out)
     try {
         for (; first != last; ++first, (void) ++current) {
             ::new (const_cast<void*>(static_cast<const volatile void*>(
-                std::addressof(*current)))) value_t{std::move(*first)};
+                std::addressof(*current)))) value_t(std::move(*first));
         }
         return current;
     } catch (...) {
@@ -134,7 +134,7 @@ auto uninitialized_copy(SourceIter first, Sent last, SinkIter out)
     IMMER_TRY {
         for (; first != last; ++first, (void) ++current) {
             ::new (const_cast<void*>(static_cast<const volatile void*>(
-                std::addressof(*current)))) value_t{*first};
+                std::addressof(*current)))) value_t(*first);
         }
         return current;
     }


### PR DESCRIPTION


In previous PR's we optimized "mutating" insertions by changing nodes in place when possible. However, whenever the change in-place was not possible because the new node needed is of a different size, the operation was performed exactly like in the immutable case.

This PR implements the realization that, when the node needs to be to be reallocated, we can still do things in a significantly faster way. In that case, we can "move" things out of the old node. When using reference counting, this means skipping touching the reference counts at all for inner nodes. For value buffers, we use std::move() potentially saving further allocations or reference count touches.

In some local testing, this brings the performance of mutating operations to 1.5X to 2.5X the performance of std::unordered_map, depending on various scenarios. This is pretty good!

This implements this optimization for insert(), set() and update(). For erase() it will come in a follow up PR.

FYI @omer-s @harryhk
