### PR TITLE
More Meta improvements

### DIFF
--- a/extra/fuzzer/map-gc.cpp
+++ b/extra/fuzzer/map-gc.cpp
@@ -53,6 +53,8 @@ extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
             op_find,
             op_update,
             op_update_move,
+            op_update_if_exists,
+            op_update_if_exists_move,
             op_diff
         };
         auto src = read<char>(in, is_valid_var);
@@ -102,6 +104,18 @@ extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
             auto key = read<size_t>(in);
             vars[dst] =
                 std::move(vars[src]).update(key, [](int x) { return x + 1; });
+            break;
+        }
+        case op_update_if_exists: {
+            auto key = read<size_t>(in);
+            vars[dst] =
+                vars[src].update_if_exists(key, [](int x) { return x + 1; });
+            break;
+        }
+        case op_update_if_exists_move: {
+            auto key  = read<size_t>(in);
+            vars[dst] = std::move(vars[src]).update_if_exists(
+                key, [](int x) { return x + 1; });
             break;
         }
         case op_diff: {

--- a/extra/fuzzer/map.cpp
+++ b/extra/fuzzer/map.cpp
@@ -41,6 +41,8 @@ extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
             op_find,
             op_update,
             op_update_move,
+            op_update_if_exists,
+            op_update_if_exists_move,
             op_diff,
         };
         auto src = read<char>(in, is_valid_var);
@@ -90,6 +92,18 @@ extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
             auto key = read<size_t>(in);
             vars[dst] =
                 std::move(vars[src]).update(key, [](int x) { return x + 1; });
+            break;
+        }
+        case op_update_if_exists: {
+            auto key = read<size_t>(in);
+            vars[dst] =
+                vars[src].update_if_exists(key, [](int x) { return x + 1; });
+            break;
+        }
+        case op_update_if_exists_move: {
+            auto key  = read<size_t>(in);
+            vars[dst] = std::move(vars[src]).update_if_exists(
+                key, [](int x) { return x + 1; });
             break;
         }
         case op_diff: {

--- a/immer/map_transient.hpp
+++ b/immer/map_transient.hpp
@@ -268,6 +268,21 @@ public:
     }
 
     /*!
+     * Replaces the association `(k, v)` by the association new association `(k,
+     * fn(v))`, where `v` is the currently associated value for `k` in the map
+     * or does nothing if `k` is not present in the map. It may allocate memory
+     * and its complexity is *effectively* @f$ O(1) @f$.
+     */
+    template <typename Fn>
+    void update_if_exists(key_type k, Fn&& fn)
+    {
+        impl_.template update_if_exists_mut<
+            typename persistent_type::project_value,
+            typename persistent_type::combine_value>(
+            *this, std::move(k), std::forward<Fn>(fn));
+    }
+
+    /*!
      * Removes the key `k` from the k.  Does nothing if the key is not
      * associated in the map.  It may allocate memory and its complexity is
      * *effectively* @f$ O(1) @f$.

--- a/immer/table.hpp
+++ b/immer/table.hpp
@@ -21,9 +21,20 @@ class table_transient;
  * It assumes the key is `id` class member.
  */
 template <typename T>
-auto get_table_key(const T& x) -> decltype(x.id)
+auto get_table_key(T const& x) -> decltype(x.id)
 {
     return x.id;
+}
+
+/*!
+ * Function template to set the key in `immer::table_key_fn`.
+ * It assumes the key is `id` class member.
+ */
+template <typename T, typename K>
+auto set_table_key(T x, K&& k) -> T
+{
+    x.id = std::forward<K>(k);
+    return x;
 }
 
 /*!
@@ -33,9 +44,15 @@ auto get_table_key(const T& x) -> decltype(x.id)
 struct table_key_fn
 {
     template <typename T>
-    decltype(auto) operator()(const T& x) const
+    decltype(auto) operator()(T&& x) const
     {
-        return get_table_key(x);
+        return get_table_key(std::forward<T>(x));
+    }
+
+    template <typename T, typename K>
+    auto operator()(T&& x, K&& k) const
+    {
+        return set_table_key(std::forward<T>(x), std::forward<K>(k));
     }
 };
 
@@ -108,9 +125,9 @@ class table
     struct combine_value
     {
         template <typename Kf, typename Tf>
-        value_t operator()(Kf&& k, Tf&& v) const
+        auto operator()(Kf&& k, Tf&& v) const
         {
-            return std::forward<Tf>(v);
+            return KeyFn{}(std::forward<Tf>(v), std::forward<Kf>(k));
         }
     };
 
@@ -133,10 +150,13 @@ class table
 
     struct hash_key
     {
-        auto operator()(const value_t& v) { return Hash{}(KeyFn{}(v)); }
+        std::size_t operator()(const value_t& v) const
+        {
+            return Hash{}(KeyFn{}(v));
+        }
 
         template <typename Key>
-        auto operator()(const Key& v)
+        std::size_t operator()(const Key& v) const
         {
             return Hash{}(v);
         }
@@ -144,14 +164,14 @@ class table
 
     struct equal_key
     {
-        auto operator()(const value_t& a, const value_t& b)
+        bool operator()(const value_t& a, const value_t& b) const
         {
             auto ke = KeyFn{};
             return Equal{}(ke(a), ke(b));
         }
 
         template <typename Key>
-        auto operator()(const value_t& a, const Key& b)
+        bool operator()(const value_t& a, const Key& b) const
         {
             return Equal{}(KeyFn{}(a), b);
         }
@@ -159,7 +179,10 @@ class table
 
     struct equal_value
     {
-        auto operator()(const value_t& a, const value_t& b) { return a == b; }
+        bool operator()(const value_t& a, const value_t& b) const
+        {
+            return a == b;
+        }
     };
 
     using impl_t =
@@ -386,8 +409,9 @@ public:
 
     /*!
      * Returns `this->insert(fn((*this)[k]))`. In particular, `fn` maps
-     * `T` to `T`. The `fn` return value should have key `k`.
-     * It may allocate memory and its complexity is *effectively* @f$ O(1) @f$.
+     * `T` to `T`. The key `k` will be replaced inside the value returned by
+     * `fn`. It may allocate memory and its complexity is *effectively* @f$ O(1)
+     * @f$.
      */
     template <typename Fn>
     IMMER_NODISCARD table update(key_type k, Fn&& fn) const&

--- a/immer/table_transient.hpp
+++ b/immer/table_transient.hpp
@@ -225,6 +225,19 @@ public:
                                   typename persistent_type::combine_value>(
             *this, std::move(k), std::forward<Fn>(fn));
     }
+
+    /*!
+     * Returns `this->insert(fn((*this)[k]))` when `this->count(k) > 0`. In
+     * particular, `fn` maps `T` to `T`. The key `k` will be replaced into the
+     * value returned by `fn`.  It may allocate memory and its complexity is
+     * *effectively* @f$ O(1) @f$.
+     */
+    template <typename Fn>
+    void update_if_exists(key_type k, Fn&& fn)
+    {
+        impl_.template update_if_exists_mut<
+            typename persistent_type::project_value,
+            typename persistent_type::combine_value>(
             *this, std::move(k), std::forward<Fn>(fn));
     }
 

--- a/immer/table_transient.hpp
+++ b/immer/table_transient.hpp
@@ -213,16 +213,18 @@ public:
     void insert(value_type value) { impl_.add_mut(*this, std::move(value)); }
 
     /*!
-     * Returns `this->insert(fn((*this)[k]))`. In particular, `fn` maps
-     * `T` to `T`. The `fn` return value should have key `k`.
-     * It may allocate memory and its complexity is *effectively* @f$ O(1) @f$.
+     * Returns `this->insert(fn((*this)[k]))`. In particular, `fn` maps `T` to
+     * `T`. The key `k` will be set into the value returned bu `fn`.  It may
+     * allocate memory and its complexity is *effectively* @f$ O(1) @f$.
      */
     template <typename Fn>
     void update(key_type k, Fn&& fn)
     {
-        impl_ = impl_.template update<persistent_type::project_value,
-                                      persistent_type::default_value,
-                                      persistent_type::combine_value>(
+        impl_.template update_mut<typename persistent_type::project_value,
+                                  typename persistent_type::default_value,
+                                  typename persistent_type::combine_value>(
+            *this, std::move(k), std::forward<Fn>(fn));
+    }
             *this, std::move(k), std::forward<Fn>(fn));
     }
 

--- a/test/map/default.cpp
+++ b/test/map/default.cpp
@@ -6,6 +6,8 @@
 // See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
 //
 
+#define IMMER_DEBUG_STATS 1
+
 #include <immer/map.hpp>
 
 #define MAP_T ::immer::map

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -165,6 +165,11 @@ TEST_CASE("equals and setting")
     CHECK(v.set(1234, 42) == v.insert({1234, 42}));
     CHECK(v.update(1234, [](auto&& x) { return x + 1; }) == v.set(1234, 1));
     CHECK(v.update(42, [](auto&& x) { return x + 1; }) == v.set(42, 43));
+
+#if IMMER_DEBUG_STATS
+    std::cout << (v.impl().get_debug_stats() + v.impl().get_debug_stats())
+                     .get_summary();
+#endif
 }
 
 TEST_CASE("iterator")

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -166,6 +166,10 @@ TEST_CASE("equals and setting")
     CHECK(v.update(1234, [](auto&& x) { return x + 1; }) == v.set(1234, 1));
     CHECK(v.update(42, [](auto&& x) { return x + 1; }) == v.set(42, 43));
 
+    CHECK(v.update_if_exists(1234, [](auto&& x) { return x + 1; }) == v);
+    CHECK(v.update_if_exists(42, [](auto&& x) { return x + 1; }) ==
+          v.set(42, 43));
+
 #if IMMER_DEBUG_STATS
     std::cout << (v.impl().get_debug_stats() + v.impl().get_debug_stats())
                      .get_summary();
@@ -259,6 +263,27 @@ TEST_CASE("update a lot")
     }
 }
 
+TEST_CASE("update_if_exists a lot")
+{
+    auto v = make_test_map(666u);
+
+    SECTION("immutable")
+    {
+        for (decltype(v.size()) i = 0; i < v.size(); ++i) {
+            v = v.update_if_exists(i, [](auto&& x) { return x + 1; });
+            CHECK(v[i] == i + 1);
+        }
+    }
+    SECTION("move")
+    {
+        for (decltype(v.size()) i = 0; i < v.size(); ++i) {
+            v = std::move(v).update_if_exists(i,
+                                              [](auto&& x) { return x + 1; });
+            CHECK(v[i] == i + 1);
+        }
+    }
+}
+
 TEST_CASE("exception safety")
 {
     constexpr auto n = 2666u;
@@ -289,6 +314,27 @@ TEST_CASE("exception safety")
         IMMER_TRACE_E(d.happenings);
     }
 
+    SECTION("update_if_exists")
+    {
+        auto v = dadaist_map_t{};
+        auto d = dadaism{};
+        for (auto i = 0u; i < n; ++i)
+            v = std::move(v).set(i, i);
+        for (auto i = 0u; i < v.size();) {
+            try {
+                auto s = d.next();
+                v      = v.update_if_exists(i, [](auto x) { return x + 1; });
+                ++i;
+            } catch (dada_error) {}
+            for (auto i : test_irange(0u, i))
+                CHECK(v.at(i) == i + 1);
+            for (auto i : test_irange(i, n))
+                CHECK(v.at(i) == i);
+        }
+        CHECK(d.happenings > 0);
+        IMMER_TRACE_E(d.happenings);
+    }
+
     SECTION("update collisisions")
     {
         auto vals = make_values_with_collisions(n);
@@ -300,6 +346,29 @@ TEST_CASE("exception safety")
             try {
                 auto s = d.next();
                 v      = v.update(vals[i].first, [](auto x) { return x + 1; });
+                ++i;
+            } catch (dada_error) {}
+            for (auto i : test_irange(0u, i))
+                CHECK(v.at(vals[i].first) == vals[i].second + 1);
+            for (auto i : test_irange(i, n))
+                CHECK(v.at(vals[i].first) == vals[i].second);
+        }
+        CHECK(d.happenings > 0);
+        IMMER_TRACE_E(d.happenings);
+    }
+
+    SECTION("update_if_exists collisisions")
+    {
+        auto vals = make_values_with_collisions(n);
+        auto v    = dadaist_conflictor_map_t{};
+        auto d    = dadaism{};
+        for (auto i = 0u; i < n; ++i)
+            v = v.insert(vals[i]);
+        for (auto i = 0u; i < v.size();) {
+            try {
+                auto s = d.next();
+                v      = v.update_if_exists(vals[i].first,
+                                       [](auto x) { return x + 1; });
                 ++i;
             } catch (dada_error) {}
             for (auto i : test_irange(0u, i))
@@ -369,6 +438,29 @@ TEST_CASE("exception safety")
                 auto s = d.next();
                 v      = std::move(v).update(vals[i].first,
                                         [](auto x) { return x + 1; });
+                ++i;
+            } catch (dada_error) {}
+            for (auto i : test_irange(0u, i))
+                CHECK(v.at(vals[i].first) == vals[i].second + 1);
+            for (auto i : test_irange(i, n))
+                CHECK(v.at(vals[i].first) == vals[i].second);
+        }
+        CHECK(d.happenings > 0);
+        IMMER_TRACE_E(d.happenings);
+    }
+
+    SECTION("update_if_exists collisisions move")
+    {
+        auto vals = make_values_with_collisions(n);
+        auto v    = dadaist_conflictor_map_t{};
+        auto d    = dadaism{};
+        for (auto i = 0u; i < n; ++i)
+            v = std::move(v).insert(vals[i]);
+        for (auto i = 0u; i < v.size();) {
+            try {
+                auto s = d.next();
+                v      = std::move(v).update_if_exists(vals[i].first,
+                                                  [](auto x) { return x + 1; });
                 ++i;
             } catch (dada_error) {}
             for (auto i : test_irange(0u, i))

--- a/test/map_transient/generic.ipp
+++ b/test/map_transient/generic.ipp
@@ -87,6 +87,14 @@ TEST_CASE("update")
     t.update("foo", [](auto x) { return x + 6; });
     CHECK(t["foo"] == 48);
     CHECK(t.size() == 2);
+
+    t.update_if_exists("foo", [](auto x) { return x + 42; });
+    CHECK(t["foo"] == 90);
+    CHECK(t.size() == 2);
+
+    t.update_if_exists("manolo", [](auto x) { return x + 42; });
+    CHECK(t["manolo"] == 0);
+    CHECK(t.size() == 2);
 }
 
 TEST_CASE("erase")

--- a/test/table/generic.ipp
+++ b/test/table/generic.ipp
@@ -282,6 +282,20 @@ TEST_CASE("update a lot")
             CHECK(v[i].second == i + 1);
         }
     }
+    SECTION("if_exists immutable")
+    {
+        for (decltype(v.size()) i = 0; i < v.size(); ++i) {
+            v = v.update_if_exists(i, incr_id);
+            CHECK(v[i].second == i + 1);
+        }
+    }
+    SECTION("if_exists move")
+    {
+        for (decltype(v.size()) i = 0; i < v.size(); ++i) {
+            v = std::move(v).update_if_exists(i, incr_id);
+            CHECK(v[i].second == i + 1);
+        }
+    }
 }
 
 TEST_CASE("exception safety")

--- a/test/table/generic.ipp
+++ b/test/table/generic.ipp
@@ -32,9 +32,23 @@ struct pair_key_fn
     }
 
     template <typename F, typename S>
+    auto operator()(std::pair<F, S> p, F k) const
+    {
+        p.first = std::move(k);
+        return p;
+    }
+
+    template <typename F, typename S>
     F operator()(const dadaist<std::pair<F, S>>& p) const
     {
         return p.value.first;
+    }
+
+    template <typename F, typename S>
+    auto operator()(dadaist<std::pair<F, S>> p, F k) const
+    {
+        p.value.first = std::move(k);
+        return p;
     }
 };
 
@@ -300,8 +314,7 @@ TEST_CASE("exception safety")
                     return make_pair(x.value.first, x.value.second + 1);
                 });
                 ++i;
-            } catch (dada_error) {
-            }
+            } catch (dada_error) {}
             for (auto i : test_irange(0u, i))
                 CHECK(v.at(i).value.second == i + 1);
             for (auto i : test_irange(i, n))
@@ -333,8 +346,7 @@ TEST_CASE("exception safety")
                     return make_pair(x.value.first, x.value.second + 1);
                 });
                 ++i;
-            } catch (dada_error) {
-            }
+            } catch (dada_error) {}
             for (auto i : test_irange(0u, i))
                 CHECK(v.at(vals[i].first).value.second == vals[i].second + 1);
             for (auto i : test_irange(i, n))
@@ -358,8 +370,7 @@ TEST_CASE("exception safety")
                     return make_pair(x.value.first, x.value.second + 1);
                 });
                 ++i;
-            } catch (dada_error) {
-            }
+            } catch (dada_error) {}
             for (auto i : test_irange(0u, i))
                 CHECK(v.at(vals[i].first).value.second == vals[i].second + 1);
             for (auto i : test_irange(i, n))
@@ -376,8 +387,7 @@ struct KeyType
 {
     explicit KeyType(uint32_t v)
         : value(v)
-    {
-    }
+    {}
     uint32_t value;
 };
 
@@ -385,8 +395,7 @@ struct LookupType
 {
     explicit LookupType(uint32_t v)
         : value(v)
-    {
-    }
+    {}
     uint32_t value;
 };
 

--- a/test/table_transient/generic.ipp
+++ b/test/table_transient/generic.ipp
@@ -16,8 +16,8 @@
 
 struct Item
 {
-    std::string id;
-    int value;
+    std::string id{};
+    int value{};
 
     bool operator==(const Item& other) const
     {
@@ -62,6 +62,20 @@ TEST_CASE("insert")
     t.insert(Item{"foo", 6});
     CHECK(t["foo"].value == 6);
     CHECK(t.size() == 2);
+
+    t.update("foo", [](auto item) {
+        item.value += 1;
+        return item;
+    });
+    CHECK(t["foo"].value == 7);
+    CHECK(t.size() == 2);
+
+    t.update("lol", [](auto item) {
+        item.value += 1;
+        return item;
+    });
+    CHECK(t["lol"].value == 1);
+    CHECK(t.size() == 3);
 }
 
 TEST_CASE("erase")

--- a/test/table_transient/generic.ipp
+++ b/test/table_transient/generic.ipp
@@ -76,6 +76,13 @@ TEST_CASE("insert")
     });
     CHECK(t["lol"].value == 1);
     CHECK(t.size() == 3);
+
+    t.update_if_exists("foo", [](auto item) {
+        item.value += 1;
+        return item;
+    });
+    CHECK(t["foo"].value == 8);
+    CHECK(t.size() == 3);
 }
 
 TEST_CASE("erase")


### PR DESCRIPTION
Among some extra fixes, this includes the changes discussed in our last meeting. This is:

- Introduce a new method `update_if_exists` that updates the value only when the key is present in the dictionary. Fixes #169 
- Improve the debugging API:
  * A new `summary` type is added to the `champ_debug_stats` to obtain the summary as a value, so you can serialize it your own way.
  * The default serialization is now done via a `operator<<`, so you can stream it to strings or other logging mecanism. This is a function of the `champ_debug_stats::summary` type.
  * The `champ_debug_stats` now provide an `operator+`, so you can accumulate statistics from multiple maps into one. 

FYI @omer-s @harryhk