### PR TITLE
Fix: iteration over data-structures would inadvertibly allow mutation + HAMT's move out value bug

### DIFF
--- a/immer/algorithm.hpp
+++ b/immer/algorithm.hpp
@@ -93,6 +93,26 @@ bool for_each_chunk_p(const T* first, const T* last, Fn&& fn)
     return std::forward<Fn>(fn)(first, last);
 }
 
+namespace detail {
+
+template <class Iter, class T>
+T accumulate_move(Iter first, Iter last, T init)
+{
+    for (; first != last; ++first)
+        init = std::move(init) + *first;
+    return init;
+}
+
+template <class Iter, class T, class Fn>
+T accumulate_move(Iter first, Iter last, T init, Fn op)
+{
+    for (; first != last; ++first)
+        init = op(std::move(init), *first);
+    return init;
+}
+
+} // namespace detail
+
 /*!
  * Equivalent of `std::accumulate` applied to the range `r`.
  */
@@ -100,7 +120,7 @@ template <typename Range, typename T>
 T accumulate(Range&& r, T init)
 {
     for_each_chunk(r, [&](auto first, auto last) {
-        init = std::accumulate(first, last, init);
+        init = detail::accumulate_move(first, last, init);
     });
     return init;
 }
@@ -109,7 +129,7 @@ template <typename Range, typename T, typename Fn>
 T accumulate(Range&& r, T init, Fn fn)
 {
     for_each_chunk(r, [&](auto first, auto last) {
-        init = std::accumulate(first, last, init, fn);
+        init = detail::accumulate_move(first, last, init, fn);
     });
     return init;
 }
@@ -122,7 +142,7 @@ template <typename Iterator, typename T>
 T accumulate(Iterator first, Iterator last, T init)
 {
     for_each_chunk(first, last, [&](auto first, auto last) {
-        init = std::accumulate(first, last, init);
+        init = detail::accumulate_move(first, last, init);
     });
     return init;
 }
@@ -131,7 +151,7 @@ template <typename Iterator, typename T, typename Fn>
 T accumulate(Iterator first, Iterator last, T init, Fn fn)
 {
     for_each_chunk(first, last, [&](auto first, auto last) {
-        init = std::accumulate(first, last, init, fn);
+        init = detail::accumulate_move(first, last, init, fn);
     });
     return init;
 }

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -635,15 +635,16 @@ struct champ
                         return {node_t::owned_values(r, e), false, false};
                     }
                 } else {
-                    auto mutate = node->can_mutate(e);
-                    auto hash2  = Hash{}(*val);
-                    auto child =
-                        node_t::make_merged_e(e,
-                                              shift + B,
-                                              std::move(v),
-                                              hash,
-                                              mutate ? std::move(*val) : *val,
-                                              hash2);
+                    auto mutate        = node->can_mutate(e);
+                    auto mutate_values = mutate && node->can_mutate_values(e);
+                    auto hash2         = Hash{}(*val);
+                    auto child         = node_t::make_merged_e(
+                        e,
+                        shift + B,
+                        std::move(v),
+                        hash,
+                        mutate_values ? std::move(*val) : *val,
+                        hash2);
                     IMMER_TRY {
                         auto r = mutate ? node_t::move_inner_replace_merged(
                                               e, node, bit, offset, child)
@@ -933,15 +934,16 @@ struct champ
                         return {node_t::owned_values(r, e), false, false};
                     }
                 } else {
-                    auto mutate = node->can_mutate(e);
-                    auto hash2  = Hash{}(*val);
-                    auto child  = node_t::make_merged_e(
+                    auto mutate        = node->can_mutate(e);
+                    auto mutate_values = mutate && node->can_mutate_values(e);
+                    auto hash2         = Hash{}(*val);
+                    auto child         = node_t::make_merged_e(
                         e,
                         shift + B,
                         Combine{}(std::forward<K>(k),
                                   std::forward<Fn>(fn)(Default{}())),
                         hash,
-                        mutate ? std::move(*val) : *val,
+                        mutate_values ? std::move(*val) : *val,
                         hash2);
                     IMMER_TRY {
                         auto r = mutate ? node_t::move_inner_replace_merged(
@@ -1013,7 +1015,8 @@ struct champ
                             node,
                             fst,
                             Combine{}(std::forward<K>(k),
-                                      std::forward<Fn>(fn)(Project{}(*fst))));
+                                      std::forward<Fn>(fn)(
+                                          Project{}(detail::as_const(*fst)))));
                         return {node_t::owned(r, e), false};
                     }
                 }
@@ -1068,7 +1071,8 @@ struct champ
                             node,
                             offset,
                             Combine{}(std::forward<K>(k),
-                                      std::forward<Fn>(fn)(Project{}(*val))));
+                                      std::forward<Fn>(fn)(
+                                          Project{}(detail::as_const(*val)))));
                         return {node_t::owned_values(r, e), false};
                     }
                 } else {

--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -246,7 +246,8 @@ struct champ
     }
 
     template <typename Fn>
-    void for_each_chunk_traversal(node_t* node, count_t depth, Fn&& fn) const
+    void
+    for_each_chunk_traversal(const node_t* node, count_t depth, Fn&& fn) const
     {
         if (depth < max_depth<B>) {
             auto datamap = node->datamap();
@@ -272,8 +273,8 @@ struct champ
     }
 
     template <typename EqualValue, typename Differ>
-    void diff(node_t* old_node,
-              node_t* new_node,
+    void diff(const node_t* old_node,
+              const node_t* new_node,
               count_t depth,
               Differ&& differ) const
     {
@@ -350,8 +351,8 @@ struct champ
     }
 
     template <typename EqualValue, typename Differ>
-    void diff_data_node(node_t* old_node,
-                        node_t* new_node,
+    void diff_data_node(const node_t* old_node,
+                        const node_t* new_node,
                         bitmap_t bit,
                         count_t depth,
                         Differ&& differ) const
@@ -379,8 +380,8 @@ struct champ
     }
 
     template <typename EqualValue, typename Differ>
-    void diff_node_data(node_t* old_node,
-                        node_t* new_node,
+    void diff_node_data(const node_t* old_node,
+                        const node_t* const new_node,
                         bitmap_t bit,
                         count_t depth,
                         Differ&& differ) const
@@ -408,8 +409,8 @@ struct champ
     }
 
     template <typename EqualValue, typename Differ>
-    void diff_data_data(node_t* old_node,
-                        node_t* new_node,
+    void diff_data_data(const node_t* old_node,
+                        const node_t* new_node,
                         bitmap_t bit,
                         Differ&& differ) const
     {
@@ -427,8 +428,9 @@ struct champ
     }
 
     template <typename EqualValue, typename Differ>
-    void
-    diff_collisions(node_t* old_node, node_t* new_node, Differ&& differ) const
+    void diff_collisions(const node_t* old_node,
+                         const node_t* new_node,
+                         Differ&& differ) const
     {
         auto old_begin = old_node->collisions();
         auto old_end   = old_node->collisions() + old_node->collision_count();
@@ -690,13 +692,13 @@ struct champ
             auto lst = fst + node->collision_count();
             for (; fst != lst; ++fst)
                 if (Equal{}(*fst, k))
-                    return {
-                        node_t::copy_collision_replace(
-                            node,
-                            fst,
-                            Combine{}(std::forward<K>(k),
-                                      std::forward<Fn>(fn)(Project{}(*fst)))),
-                        false};
+                    return {node_t::copy_collision_replace(
+                                node,
+                                fst,
+                                Combine{}(std::forward<K>(k),
+                                          std::forward<Fn>(fn)(Project{}(
+                                              detail::as_const(*fst))))),
+                            false};
             return {node_t::copy_collision_insert(
                         node,
                         Combine{}(std::forward<K>(k),
@@ -726,13 +728,13 @@ struct champ
                 auto offset = node->data_count(bit);
                 auto val    = node->values() + offset;
                 if (Equal{}(*val, k))
-                    return {
-                        node_t::copy_inner_replace_value(
-                            node,
-                            offset,
-                            Combine{}(std::forward<K>(k),
-                                      std::forward<Fn>(fn)(Project{}(*val)))),
-                        false};
+                    return {node_t::copy_inner_replace_value(
+                                node,
+                                offset,
+                                Combine{}(std::forward<K>(k),
+                                          std::forward<Fn>(fn)(Project{}(
+                                              detail::as_const(*val))))),
+                            false};
                 else {
                     auto child = node_t::make_merged(
                         shift + B,
@@ -789,7 +791,8 @@ struct champ
                         node,
                         fst,
                         Combine{}(std::forward<K>(k),
-                                  std::forward<Fn>(fn)(Project{}(*fst))));
+                                  std::forward<Fn>(fn)(
+                                      Project{}(detail::as_const(*fst)))));
             return nullptr;
         } else {
             auto idx = (hash & (mask<B> << shift)) >> shift;
@@ -819,7 +822,8 @@ struct champ
                         node,
                         offset,
                         Combine{}(std::forward<K>(k),
-                                  std::forward<Fn>(fn)(Project{}(*val))));
+                                  std::forward<Fn>(fn)(
+                                      Project{}(detail::as_const(*val)))));
                 else {
                     return nullptr;
                 }
@@ -871,7 +875,8 @@ struct champ
                             node,
                             fst,
                             Combine{}(std::forward<K>(k),
-                                      std::forward<Fn>(fn)(Project{}(*fst))));
+                                      std::forward<Fn>(fn)(
+                                          Project{}(detail::as_const(*fst)))));
                         return {node_t::owned(r, e), false, false};
                     }
                 }
@@ -923,7 +928,8 @@ struct champ
                             node,
                             offset,
                             Combine{}(std::forward<K>(k),
-                                      std::forward<Fn>(fn)(Project{}(*val))));
+                                      std::forward<Fn>(fn)(
+                                          Project{}(detail::as_const(*val)))));
                         return {node_t::owned_values(r, e), false, false};
                     }
                 } else {

--- a/immer/detail/rbts/operations.hpp
+++ b/immer/detail/rbts/operations.hpp
@@ -92,7 +92,7 @@ struct for_each_chunk_visitor : visitor_base<for_each_chunk_visitor>
     static void visit_leaf(Pos&& pos, Fn&& fn)
     {
         auto data = pos.node()->leaf();
-        fn(data, data + pos.count());
+        fn(as_const(data), as_const(data) + pos.count());
     }
 };
 
@@ -109,7 +109,7 @@ struct for_each_chunk_p_visitor : visitor_base<for_each_chunk_p_visitor>
     template <typename Pos, typename Fn>
     static bool visit_leaf(Pos&& pos, Fn&& fn)
     {
-        auto data = pos.node()->leaf();
+        auto data = as_const(pos.node()->leaf());
         return fn(data, data + pos.count());
     }
 };

--- a/immer/detail/util.hpp
+++ b/immer/detail/util.hpp
@@ -25,6 +25,18 @@ namespace immer {
 namespace detail {
 
 template <typename T>
+const T* as_const(T* x)
+{
+    return x;
+}
+
+template <typename T>
+const T& as_const(T& x)
+{
+    return x;
+}
+
+template <typename T>
 using aligned_storage_for =
     typename std::aligned_storage<sizeof(T), alignof(T)>::type;
 
@@ -113,7 +125,8 @@ auto uninitialized_move(Iter1 first, Iter1 last, Iter2 out)
                 std::addressof(*current)))) value_t(std::move(*first));
         }
         return current;
-    } IMMER_CATCH (...) {
+    }
+    IMMER_CATCH (...) {
         detail::destroy(out, current);
         IMMER_RETHROW;
     }

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -170,6 +170,8 @@ public:
 
     using transient_type = map_transient<K, T, Hash, Equal, MemoryPolicy, B>;
 
+    using memory_policy_type = MemoryPolicy;
+
     /*!
      * Constructs a map containing the elements in `values`.
      */

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -85,6 +85,8 @@ public:
 
     using transient_type = set_transient<T, Hash, Equal, MemoryPolicy, B>;
 
+    using memory_policy_type = MemoryPolicy;
+
     /*!
      * Default constructor.  It creates a set of `size() == 0`.  It
      * does not allocate memory and its complexity is @f$ O(1) @f$.

--- a/immer/table.hpp
+++ b/immer/table.hpp
@@ -206,6 +206,8 @@ public:
     using transient_type =
         table_transient<T, KeyFn, Hash, Equal, MemoryPolicy, B>;
 
+    using memory_policy_type = MemoryPolicy;
+
     /*!
      * Constructs a table containing the elements in `values`.
      */

--- a/test/algorithm.cpp
+++ b/test/algorithm.cpp
@@ -1,0 +1,221 @@
+#include <immer/array.hpp>
+#include <immer/flex_vector.hpp>
+#include <immer/map.hpp>
+#include <immer/set.hpp>
+#include <immer/table.hpp>
+#include <immer/vector.hpp>
+
+#include <immer/algorithm.hpp>
+
+#include <catch.hpp>
+
+struct thing
+{
+    int id = 0;
+};
+bool operator==(const thing& a, const thing& b) { return a.id == b.id; }
+
+TEST_CASE("iteration exposes const")
+{
+    auto do_check = [](auto v) {
+        using value_t = typename decltype(v)::value_type;
+        immer::for_each(v, [](auto&& x) {
+            static_assert(std::is_same<const value_t&, decltype(x)>::value, "");
+        });
+    };
+
+    do_check(immer::vector<int>{});
+    do_check(immer::flex_vector<int>{});
+    do_check(immer::array<int>{});
+    do_check(immer::map<int, int>{});
+    do_check(immer::set<int>{});
+    do_check(immer::table<thing>{});
+}
+
+TEST_CASE("chunked iteration exposes const")
+{
+    auto do_check = [](auto v) {
+        using value_t = typename decltype(v)::value_type;
+        immer::for_each_chunk(v, [](auto a, auto b) {
+            static_assert(std::is_same<const value_t*, decltype(a)>::value, "");
+            static_assert(std::is_same<const value_t*, decltype(b)>::value, "");
+        });
+    };
+
+    do_check(immer::vector<int>{});
+    do_check(immer::flex_vector<int>{});
+    do_check(immer::array<int>{});
+    do_check(immer::map<int, int>{});
+    do_check(immer::set<int>{});
+    do_check(immer::table<thing>{});
+}
+
+TEST_CASE("accumulate")
+{
+    auto do_check = [](auto v) {
+        using value_t = typename decltype(v)::value_type;
+        immer::accumulate(v, value_t{}, [](auto&& a, auto&& b) {
+            static_assert(std::is_same<value_t&&, decltype(a)>::value, "");
+            static_assert(std::is_same<const value_t&, decltype(b)>::value, "");
+            return std::move(a);
+        });
+    };
+
+    do_check(immer::vector<int>{});
+    do_check(immer::flex_vector<int>{});
+    do_check(immer::array<int>{});
+    do_check(immer::map<int, int>{});
+    do_check(immer::set<int>{});
+    do_check(immer::table<thing>{});
+}
+
+TEST_CASE("diffing exposes const")
+{
+    auto do_check = [](auto v) {
+        using value_t = typename decltype(v)::value_type;
+        immer::diff(
+            v,
+            v,
+            [](auto&& x) {
+                static_assert(std::is_same<const value_t&, decltype(x)>::value,
+                              "");
+            },
+            [](auto&& x) {
+                static_assert(std::is_same<const value_t&, decltype(x)>::value,
+                              "");
+            },
+            [](auto&& x, auto&& y) {
+                static_assert(std::is_same<const value_t&, decltype(x)>::value,
+                              "");
+                static_assert(std::is_same<const value_t&, decltype(y)>::value,
+                              "");
+            });
+    };
+
+    do_check(immer::map<int, int>{});
+    do_check(immer::set<int>{});
+    do_check(immer::table<thing>{});
+}
+
+TEST_CASE("all_of")
+{
+    auto do_check = [](auto v) {
+        using value_t = typename decltype(v)::value_type;
+        immer::all_of(v, [](auto&& x) {
+            static_assert(std::is_same<const value_t&, decltype(x)>::value, "");
+            return true;
+        });
+    };
+
+    do_check(immer::vector<int>{});
+    do_check(immer::flex_vector<int>{});
+    do_check(immer::array<int>{});
+    // not supported
+    // do_check(immer::map<int, int>{});
+    // do_check(immer::set<int>{});
+    // do_check(immer::table<thing>{});
+}
+
+TEST_CASE("update vectors")
+{
+    auto do_check = [](auto v) {
+        if (false)
+            (void) v.update(0, [](auto&& x) {
+                using type_t = std::decay_t<decltype(x)>;
+                // vectors do copy first the whole array, and then move the
+                // copied value into the function
+                static_assert(std::is_same<type_t&&, decltype(x)>::value, "");
+                return x;
+            });
+    };
+
+    do_check(immer::vector<int>{});
+    do_check(immer::flex_vector<int>{});
+    do_check(immer::array<int>{});
+}
+
+TEST_CASE("update maps")
+{
+    auto do_check = [](auto v) {
+        (void) v.update(0, [](auto&& x) {
+            using type_t = std::decay_t<decltype(x)>;
+            // for maps, we actually do not make a copy at all but pase the
+            // original instance directly, as const..
+            static_assert(std::is_same<const type_t&, decltype(x)>::value, "");
+            return x;
+        });
+    };
+
+    do_check(immer::map<int, int>{});
+    do_check(immer::table<thing>{});
+}
+
+TEST_CASE("update_if_exists maps")
+{
+    auto do_check = [](auto v) {
+        (void) v.update_if_exists(0, [](auto&& x) {
+            using type_t = std::decay_t<decltype(x)>;
+            // for maps, we actually do not make a copy at all but pase the
+            // original instance directly, as const..
+            static_assert(std::is_same<const type_t&, decltype(x)>::value, "");
+            return x;
+        });
+    };
+
+    do_check(immer::map<int, int>{});
+    do_check(immer::table<thing>{});
+}
+
+TEST_CASE("update vectors move")
+{
+    auto do_check = [](auto v) {
+        if (false)
+            (void) std::move(v).update(0, [](auto&& x) {
+                using type_t = std::decay_t<decltype(x)>;
+                // vectors do copy first the whole array, and then move the
+                // copied value into the function
+                static_assert(std::is_same<type_t&&, decltype(x)>::value, "");
+                return x;
+            });
+    };
+
+    do_check(immer::vector<int>{});
+    do_check(immer::flex_vector<int>{});
+    do_check(immer::array<int>{});
+}
+
+TEST_CASE("update maps move")
+{
+    auto do_check = [](auto v) {
+        (void) std::move(v).update(0, [](auto&& x) {
+            using type_t = std::decay_t<decltype(x)>;
+            // for maps, we actually do not make a copy at all but pase the
+            // original instance directly, as const..
+            static_assert(std::is_same<const type_t&, decltype(x)>::value ||
+                              std::is_same<type_t&&, decltype(x)>::value,
+                          "");
+            return x;
+        });
+    };
+
+    do_check(immer::map<int, int>{});
+    do_check(immer::table<thing>{});
+}
+
+TEST_CASE("update_if_exists maps move")
+{
+    auto do_check = [](auto v) {
+        (void) std::move(v).update_if_exists(0, [](auto&& x) {
+            using type_t = std::decay_t<decltype(x)>;
+            // for maps, we actually do not make a copy at all but pase the
+            // original instance directly, as const..
+            static_assert(std::is_same<const type_t&, decltype(x)>::value ||
+                              std::is_same<type_t&&, decltype(x)>::value,
+                          "");
+            return x;
+        });
+    };
+
+    do_check(immer::map<int, int>{});
+    do_check(immer::table<thing>{});
+}

--- a/test/map/gc.cpp
+++ b/test/map/gc.cpp
@@ -23,4 +23,5 @@ template <typename K,
 using test_map_t = immer::map<K, T, Hash, Eq, gc_memory, 3u>;
 
 #define MAP_T test_map_t
+#define IMMER_IS_LIBGC_TEST 1
 #include "generic.ipp"

--- a/test/set/gc.cpp
+++ b/test/set/gc.cpp
@@ -22,4 +22,6 @@ template <typename T,
 using test_set_t = immer::set<T, Hash, Eq, gc_memory, 3u>;
 
 #define SET_T test_set_t
+#define IMMER_IS_LIBGC_TEST 1
+
 #include "generic.ipp"


### PR DESCRIPTION
1. This solves an issue where:
```c++
auto v = immer::vector<int>{};
immer::for_each(v, [](int& x) {
  x = 42;
})
```
Would work, mutating the contents of the vector!!! This problem did exist for various callback-based functions. This fixes it everywhere.

2. This also solves an issue where transient updates on HAMT's would be too eager, moving out values that they should really not move!

FYI @omer-s @harryhk