### PR TITLE
Remove all usage of `dec_unsafe` from the code-base

### DIFF
--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -604,8 +604,8 @@ struct champ
                     auto result =
                         do_add_mut(e, child, std::move(v), hash, shift + B);
                     node->children()[offset] = result.node;
-                    if (!result.mutated)
-                        child->dec_unsafe();
+                    if (!result.mutated && child->dec())
+                        node_t::delete_deep_shift(child, shift + B);
                     return {node, result.added, true};
                 } else {
                     assert(node->children()[offset]);
@@ -672,8 +672,8 @@ struct champ
     {
         auto hash = Hash{}(v);
         auto res  = do_add_mut(e, root, std::move(v), hash, 0);
-        if (!res.mutated)
-            root->dec_unsafe();
+        if (!res.mutated && root->dec())
+            node_t::delete_deep(root, 0);
         root = res.node;
         size += res.added ? 1 : 0;
     }
@@ -897,8 +897,8 @@ struct champ
                     auto result = do_update_mut<Project, Default, Combine>(
                         e, child, k, std::forward<Fn>(fn), hash, shift + B);
                     node->children()[offset] = result.node;
-                    if (!result.mutated)
-                        child->dec_unsafe();
+                    if (!result.mutated && child->dec())
+                        node_t::delete_deep_shift(child, shift + B);
                     return {node, result.added, true};
                 } else {
                     auto result = do_update<Project, Default, Combine>(
@@ -980,8 +980,8 @@ struct champ
         auto hash = Hash{}(k);
         auto res  = do_update_mut<Project, Default, Combine>(
             e, root, k, std::forward<Fn>(fn), hash, 0);
-        if (!res.mutated)
-            root->dec_unsafe();
+        if (!res.mutated && root->dec())
+            node_t::delete_deep(root, 0);
         root = res.node;
         size += res.added ? 1 : 0;
     }
@@ -1032,8 +1032,8 @@ struct champ
                         e, child, k, std::forward<Fn>(fn), hash, shift + B);
                     if (result.node) {
                         node->children()[offset] = result.node;
-                        if (!result.mutated)
-                            child->dec_unsafe();
+                        if (!result.mutated && child->dec())
+                            node_t::delete_deep_shift(child, shift + B);
                         return {node, true};
                     } else {
                         return {nullptr, false};
@@ -1091,8 +1091,8 @@ struct champ
         auto res  = do_update_if_exists_mut<Project, Combine>(
             e, root, k, std::forward<Fn>(fn), hash, 0);
         if (res.node) {
-            if (!res.mutated)
-                root->dec_unsafe();
+            if (!res.mutated && root->dec())
+                node_t::delete_deep(root, 0);
             root = res.node;
         }
     }
@@ -1305,8 +1305,8 @@ struct champ
                         shift > 0) {
                         if (mutate) {
                             node_t::delete_inner(node);
-                            if (!result.mutated)
-                                child->dec_unsafe();
+                            if (!result.mutated && child->dec())
+                                node_t::delete_deep_shift(child, shift + B);
                         }
                         return {result.data.singleton, mutate};
                     } else {
@@ -1326,15 +1326,15 @@ struct champ
                                          *result.data.singleton);
                         if (result.mutated)
                             detail::destroy_at(result.data.singleton);
-                        else if (mutate)
-                            child->dec_unsafe();
+                        else if (mutate && child->dec())
+                            node_t::delete_deep_shift(child, shift + B);
                         return {node_t::owned_values(r, e), mutate};
                     }
                 case sub_result::tree:
                     if (mutate) {
                         children[offset] = result.data.tree;
-                        if (!result.mutated)
-                            child->dec_unsafe();
+                        if (!result.mutated && child->dec())
+                            node_t::delete_deep_shift(child, shift + B);
                         return {node, true};
                     } else {
                         IMMER_TRY {
@@ -1403,8 +1403,8 @@ struct champ
         case sub_result::nothing:
             break;
         case sub_result::tree:
-            if (!res.mutated)
-                root->dec_unsafe();
+            if (!res.mutated && root->dec())
+                node_t::delete_deep(root, 0);
             root = res.data.tree;
             --size;
             break;

--- a/immer/detail/rbts/operations.hpp
+++ b/immer/detail/rbts/operations.hpp
@@ -468,9 +468,8 @@ struct update_visitor : visitor_base<update_visitor<NodeT>>
         auto node   = node_t::make_inner_sr_n(count, pos.relaxed());
         IMMER_TRY {
             auto child = pos.towards_oh(this_t{}, idx, offset, fn);
-            node_t::do_copy_inner_sr(node, pos.node(), count);
-            node->inner()[offset]->dec_unsafe();
-            node->inner()[offset] = child;
+            node_t::do_copy_inner_replace_sr(
+                node, pos.node(), count, offset, child);
             return node;
         }
         IMMER_CATCH (...) {
@@ -487,9 +486,8 @@ struct update_visitor : visitor_base<update_visitor<NodeT>>
         auto node   = node_t::make_inner_n(count);
         IMMER_TRY {
             auto child = pos.towards_oh_ch(this_t{}, idx, offset, count, fn);
-            node_t::do_copy_inner(node, pos.node(), count);
-            node->inner()[offset]->dec_unsafe();
-            node->inner()[offset] = child;
+            node_t::do_copy_inner_replace(
+                node, pos.node(), count, offset, child);
             return node;
         }
         IMMER_CATCH (...) {

--- a/immer/refcount/no_refcount_policy.hpp
+++ b/immer/refcount/no_refcount_policy.hpp
@@ -24,7 +24,6 @@ struct no_refcount_policy
 
     void inc() {}
     bool dec() { return false; }
-    void dec_unsafe() {}
     bool unique() { return false; }
 };
 

--- a/immer/refcount/refcount_policy.hpp
+++ b/immer/refcount/refcount_policy.hpp
@@ -34,12 +34,6 @@ struct refcount_policy
 
     bool dec() { return 1 == refcount.fetch_sub(1, std::memory_order_acq_rel); }
 
-    void dec_unsafe()
-    {
-        assert(refcount.load() > 1);
-        refcount.fetch_sub(1, std::memory_order_relaxed);
-    }
-
     bool unique() { return refcount == 1; }
 };
 

--- a/immer/refcount/unsafe_refcount_policy.hpp
+++ b/immer/refcount/unsafe_refcount_policy.hpp
@@ -31,7 +31,6 @@ struct unsafe_refcount_policy
 
     void inc() { ++refcount; }
     bool dec() { return --refcount == 0; }
-    void dec_unsafe() { --refcount; }
     bool unique() { return refcount == 1; }
 };
 

--- a/test/memory/refcounts.cpp
+++ b/test/memory/refcounts.cpp
@@ -42,16 +42,6 @@ void test_refcount()
         CHECK(!elem.dec());
         CHECK(elem.dec());
     }
-
-    SECTION("inc dec unsafe")
-    {
-        refcount elem{};
-        elem.inc();
-        CHECK(!elem.dec());
-        elem.inc();
-        elem.dec_unsafe();
-        CHECK(elem.dec());
-    }
 }
 
 TEST_CASE("basic refcount") { test_refcount<immer::refcount_policy>(); }


### PR DESCRIPTION
The `dec_unsafe()` member of the refcount policies allows one to decrement the reference count without dealing with the resulting reference count. While there are some very rare situations where that is safe to do, in reality, this can lead to rare but subtle memory leaks when in a multi-threaded context.

Therefore, I have decided to remove this method completely. In most cases, we just replace it with a call to `dec()`.

In most scenarios this change should not affect performance. There are a couple of cases in the vector implementation where it may even improve it, as we touch reference counts less.

FYI @omer-s @harryhk