### PR TITLE
Fix debug stats

### DIFF
--- a/immer/detail/hamts/champ.hpp
+++ b/immer/detail/hamts/champ.hpp
@@ -94,21 +94,26 @@ struct champ_debug_stats
             100. * (value_count * value_size + child_count * child_size) /
             (capacity * value_size + capacity * child_size);
 
-        auto value_capacity          = m * inner_node_w_value_count;
-        auto child_capacity          = m * inner_node_w_child_count;
-        auto dense_child_utilization = 100. * child_count / child_capacity;
-        auto dense_value_utilization = 100. * value_count / value_capacity;
+        auto value_capacity = m * inner_node_w_value_count;
+        auto child_capacity = m * inner_node_w_child_count;
+        auto dense_child_utilization =
+            child_capacity == 0 ? 100. : 100. * child_count / child_capacity;
+        auto dense_value_utilization =
+            value_capacity == 0 ? 100. : 100. * value_count / value_capacity;
         auto dense_utilization =
-            100. * (value_count * value_size + child_count * child_size) /
-            (value_capacity * value_size + child_capacity * child_size);
+            value_capacity + child_capacity == 0
+                ? 100.
+                : 100. * (value_count * value_size + child_count * child_size) /
+                      (value_capacity * value_size +
+                       child_capacity * child_size);
 
         return {collision_ratio,
                 utilization,
                 child_utilization,
                 value_utilization,
                 dense_utilization,
-                dense_child_utilization,
-                dense_value_utilization};
+                dense_value_utilization,
+                dense_child_utilization};
     }
 };
 #endif

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -179,6 +179,23 @@ TEST_CASE("equals and setting")
 #endif
 }
 
+#if IMMER_DEBUG_STATS
+TEST_CASE("debug stats")
+{
+    {
+        std::cout
+            << immer::map<int, int>{}.impl().get_debug_stats().get_summary();
+    }
+    {
+        immer::map<int, int> map;
+        for (int i = 0; i <= 10; i++) {
+            map = std::move(map).set(i, i);
+        }
+        std::cout << map.impl().get_debug_stats().get_summary();
+    }
+}
+#endif
+
 TEST_CASE("iterator")
 {
     const auto N = 666u;


### PR DESCRIPTION
This fixes a couple of issues:

1. The dense value and child utilizations were swapped.
2. You could get inocuous `nan`s when there were no child or no values when computing the dense utilization.

FYI @omer-s @harryhk