### PR TITLE
`flex_vector` nothrow move constructible/assignable

### DIFF
--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -330,7 +330,7 @@ struct node
     static node_t* make_leaf_n(count_t n)
     {
         assert(n <= branches<BL>);
-        auto m  =heap::allocate(sizeof_leaf_n(n));
+        auto m = heap::allocate(sizeof_leaf_n(n));
         return make_leaf_n_into(m, sizeof_leaf_n(n), n);
     }
 

--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -199,16 +199,22 @@ struct node
     }
     static ownee_t& ownee(node_t* x) { return get<ownee_t>(x->impl); }
 
-    static node_t* make_inner_n(count_t n)
+    static node_t* make_inner_n_into(void* buffer, std::size_t size, count_t n)
     {
         assert(n <= branches<B>);
-        auto m                       = heap::allocate(sizeof_inner_n(n));
-        auto p                       = new (m) node_t;
+        assert(size >= sizeof_inner_n(n));
+        auto p                       = new (buffer) node_t;
         p->impl.d.data.inner.relaxed = nullptr;
 #if IMMER_TAGGED_NODE
         p->impl.d.kind = node_t::kind_t::inner;
 #endif
         return p;
+    }
+    static node_t* make_inner_n(count_t n)
+    {
+        assert(n <= branches<B>);
+        auto m = heap::allocate(sizeof_inner_n(n));
+        return make_inner_n_into(m, sizeof_inner_n(n), n);
     }
 
     static node_t* make_inner_e(edit_t e)
@@ -310,14 +316,22 @@ struct node
             });
     }
 
-    static node_t* make_leaf_n(count_t n)
+    static node_t* make_leaf_n_into(void* buffer, std::size_t size, count_t n)
     {
         assert(n <= branches<BL>);
-        auto p = new (heap::allocate(sizeof_leaf_n(n))) node_t;
+        assert(size >= sizeof_leaf_n(n));
+        auto p = new (buffer) node_t;
 #if IMMER_TAGGED_NODE
         p->impl.d.kind = node_t::kind_t::leaf;
 #endif
         return p;
+    }
+
+    static node_t* make_leaf_n(count_t n)
+    {
+        assert(n <= branches<BL>);
+        auto m  =heap::allocate(sizeof_leaf_n(n));
+        return make_leaf_n_into(m, sizeof_leaf_n(n), n);
     }
 
     static node_t* make_leaf_e(edit_t e)

--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -50,17 +50,20 @@ struct rrbtree
     static node_t* empty_root()
     {
         constexpr auto size = node_t::sizeof_inner_n(0);
-        static std::aligned_storage_t<size, alignof(std::max_align_t)> storage;
-        static const auto empty_ =
-            node_t::make_inner_n_into(&storage, size, 0u);
+        static const auto empty_ = [&]{
+            static std::aligned_storage_t<size, alignof(std::max_align_t)> storage;
+            return node_t::make_inner_n_into(&storage, size, 0u);
+        }();
         return empty_->inc();
     }
 
     static node_t* empty_tail()
     {
         constexpr auto size = node_t::sizeof_leaf_n(0);
-        static std::aligned_storage_t<size, alignof(std::max_align_t)> storage;
-        static const auto empty_ = node_t::make_leaf_n_into(&storage, size, 0u);
+        static const auto empty_ = [&]{
+            static std::aligned_storage_t<size, alignof(std::max_align_t)> storage;
+            return node_t::make_leaf_n_into(&storage, size, 0u);
+        }();
         return empty_->inc();
     }
 

--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -49,13 +49,18 @@ struct rrbtree
 
     static node_t* empty_root()
     {
-        static const auto empty_ = node_t::make_inner_n(0u);
+        constexpr auto size = node_t::sizeof_inner_n(0);
+        static std::aligned_storage_t<size, alignof(std::max_align_t)> storage;
+        static const auto empty_ =
+            node_t::make_inner_n_into(&storage, size, 0u);
         return empty_->inc();
     }
 
     static node_t* empty_tail()
     {
-        static const auto empty_ = node_t::make_leaf_n(0u);
+        constexpr auto size = node_t::sizeof_leaf_n(0);
+        static std::aligned_storage_t<size, alignof(std::max_align_t)> storage;
+        static const auto empty_ = node_t::make_leaf_n_into(&storage, size, 0u);
         return empty_->inc();
     }
 
@@ -90,7 +95,7 @@ struct rrbtree
         return result;
     }
 
-    rrbtree()
+    rrbtree() noexcept
         : size{0}
         , shift{BL}
         , root{empty_root()}
@@ -99,7 +104,7 @@ struct rrbtree
         assert(check_tree());
     }
 
-    rrbtree(size_t sz, shift_t sh, node_t* r, node_t* t)
+    rrbtree(size_t sz, shift_t sh, node_t* r, node_t* t) noexcept
         : size{sz}
         , shift{sh}
         , root{r}
@@ -108,13 +113,13 @@ struct rrbtree
         assert(check_tree());
     }
 
-    rrbtree(const rrbtree& other)
+    rrbtree(const rrbtree& other) noexcept
         : rrbtree{other.size, other.shift, other.root, other.tail}
     {
         inc();
     }
 
-    rrbtree(rrbtree&& other)
+    rrbtree(rrbtree&& other) noexcept
         : rrbtree{}
     {
         swap(*this, other);
@@ -127,13 +132,13 @@ struct rrbtree
         return *this;
     }
 
-    rrbtree& operator=(rrbtree&& other)
+    rrbtree& operator=(rrbtree&& other) noexcept
     {
         swap(*this, other);
         return *this;
     }
 
-    friend void swap(rrbtree& x, rrbtree& y)
+    friend void swap(rrbtree& x, rrbtree& y) noexcept
     {
         using std::swap;
         swap(x.size, y.size);

--- a/immer/flex_vector.hpp
+++ b/immer/flex_vector.hpp
@@ -616,7 +616,9 @@ private:
     impl_t impl_ = {};
 };
 
-static_assert(std::is_nothrow_move_constructible<flex_vector<int>>::value);
-static_assert(std::is_nothrow_move_assignable<flex_vector<int>>::value);
+static_assert(std::is_nothrow_move_constructible<flex_vector<int>>::value,
+              "flex_vector is not nothrow move constructible");
+static_assert(std::is_nothrow_move_assignable<flex_vector<int>>::value,
+              "flex_vector is not nothrow move assignable");
 
 } // namespace immer

--- a/immer/flex_vector.hpp
+++ b/immer/flex_vector.hpp
@@ -616,4 +616,7 @@ private:
     impl_t impl_ = {};
 };
 
+static_assert(std::is_nothrow_move_constructible<flex_vector<int>>::value);
+static_assert(std::is_nothrow_move_assignable<flex_vector<int>>::value);
+
 } // namespace immer


### PR DESCRIPTION
This is a result of https://github.com/arximboldi/immer/issues/244.

This is just an idea how one could make the move constructor and assignment operator `noexcept`.
I used `aligned_storage` to statically reserve some memory for the nodes.

However, while I type this description I noticed a problem: I'm not familiar with the mechanism the frees memory. There is nothing that prevents the code from attempting to free the statically allocated buffers.
A possible solution would be to keep the ref count always above 0. 