### PR TITLE
Add export CMake Config version file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,14 @@ install(TARGETS immer EXPORT ImmerConfig)
 install(EXPORT ImmerConfig DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Immer")
 install(DIRECTORY immer DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/ImmerConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion )
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/ImmerConfigVersion.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Immer" )
+
 # development target to be used in tests, examples, benchmarks...
 immer_canonicalize_cmake_booleans(
   DISABLE_FREE_LIST

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ install(DIRECTORY immer DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-  ${CMAKE_CURRENT_BINARY_DIR}/ImmerConfigVersion.cmake
+  "${CMAKE_CURRENT_BINARY_DIR}/ImmerConfigVersion.cmake"
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY SameMajorVersion )
 


### PR DESCRIPTION
There is an vcpkg issue: https://github.com/microsoft/vcpkg/issues/28864, some users need use `find_package(immer VERSION 0.8.0)` feature. 

But this port doesn't have this feature. So I submit this PR to add export CMake Config version file, this will fix the use of find special version of `immer` like `find_package(immer VERSION 0.8.0)`, the parameter `SameMajorVersion` applies to the version with major 0.