### PR TITLE
Make pretty-printer loading more robust

### DIFF
--- a/tools/gdb_pretty_printers/autoload.py
+++ b/tools/gdb_pretty_printers/autoload.py
@@ -1,7 +1,10 @@
 import gdb.printing
 import os
+import sys
+import inspect
 
-path = os.path.dirname(__file__)
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
 if not path in sys.path:
     sys.path.append(path)
 from printers import immer_lookup_function


### PR DESCRIPTION
A while after making the initial commit in #255, it came to my attention that `__file__` isn't actually a terribly reliable way to find the source filename. This change should make the loading process more robust, and work in more contexts.