### PR TITLE
Fixes and tests for C++20 Range compatibility

### DIFF
--- a/immer/detail/hamts/champ_iterator.hpp
+++ b/immer/detail/hamts/champ_iterator.hpp
@@ -27,6 +27,8 @@ struct champ_iterator
     using tree_t = champ<T, Hash, Eq, MP, B>;
     using node_t = typename tree_t::node_t;
 
+    champ_iterator() = default;
+
     struct end_t
     {};
 

--- a/immer/detail/iterator_facade.hpp
+++ b/immer/detail/iterator_facade.hpp
@@ -101,7 +101,7 @@ public:
     ReferenceT operator[](DifferenceTypeT n) const
     {
         static_assert(is_random_access, "");
-        return derived() + n;
+        return *(derived() + n);
     }
 
     friend bool operator==(const DerivedT& a, const DerivedT& b)

--- a/immer/detail/iterator_facade.hpp
+++ b/immer/detail/iterator_facade.hpp
@@ -82,19 +82,6 @@ protected:
         std::is_base_of<std::bidirectional_iterator_tag,
                         IteratorCategoryT>::value;
 
-    class reference_proxy
-    {
-        friend iterator_facade;
-        DerivedT iter_;
-
-        reference_proxy(DerivedT iter)
-            : iter_{std::move(iter)}
-        {}
-
-    public:
-        operator ReferenceT() const { return *iter_; }
-    };
-
     const DerivedT& derived() const
     {
         static_assert(std::is_base_of<iterator_facade, DerivedT>::value,
@@ -111,7 +98,7 @@ protected:
 public:
     ReferenceT operator*() const { return access_t::dereference(derived()); }
     PointerT operator->() const { return &access_t::dereference(derived()); }
-    reference_proxy operator[](DifferenceTypeT n) const
+    ReferenceT operator[](DifferenceTypeT n) const
     {
         static_assert(is_random_access, "");
         return derived() + n;

--- a/test/array_transient/default.cpp
+++ b/test/array_transient/default.cpp
@@ -14,6 +14,10 @@
 
 #include "../vector_transient/generic.ipp"
 
+IMMER_RANGES_CHECK(std::ranges::contiguous_range<immer::array<std::string>>);
+IMMER_RANGES_CHECK(
+    std::ranges::contiguous_range<immer::array_transient<std::string>>);
+
 TEST_CASE("array_transient default constructor compiles")
 {
     immer::array_transient<int> transient;

--- a/test/flex_vector/generic.ipp
+++ b/test/flex_vector/generic.ipp
@@ -29,7 +29,8 @@
 #error "define the vector template to use in VECTOR_T"
 #endif
 
-IMMER_RANGES_CHECK(std::ranges::random_access_range<FLEX_VECTOR_T<std::string>>);
+IMMER_RANGES_CHECK(
+    std::ranges::random_access_range<FLEX_VECTOR_T<std::string>>);
 
 template <typename V = FLEX_VECTOR_T<unsigned>>
 auto make_test_flex_vector(unsigned min, unsigned max)
@@ -106,6 +107,18 @@ TEST_CASE("push_front")
         for (decltype(v.size()) j = 0; j < v.size(); ++j)
             CHECK(v[v.size() - j - 1] == j);
     }
+}
+
+TEST_CASE("random_access iteration")
+{
+    auto v    = make_test_flex_vector(0, 10);
+    auto iter = v.begin();
+    CHECK(*iter == 0);
+    CHECK(iter[0] == 0);
+    CHECK(iter[3] == 3);
+    CHECK(iter[9] == 9);
+    iter += 4;
+    CHECK(iter[-4] == 0);
 }
 
 TEST_CASE("concat")

--- a/test/flex_vector/generic.ipp
+++ b/test/flex_vector/generic.ipp
@@ -29,6 +29,8 @@
 #error "define the vector template to use in VECTOR_T"
 #endif
 
+IMMER_RANGES_CHECK(std::ranges::random_access_range<FLEX_VECTOR_T<std::string>>);
+
 template <typename V = FLEX_VECTOR_T<unsigned>>
 auto make_test_flex_vector(unsigned min, unsigned max)
 {

--- a/test/flex_vector_transient/generic.ipp
+++ b/test/flex_vector_transient/generic.ipp
@@ -33,6 +33,11 @@
 #error "define the vector template to use in VECTOR_T"
 #endif
 
+IMMER_RANGES_CHECK(
+    std::ranges::random_access_range<FLEX_VECTOR_T<std::string>>);
+IMMER_RANGES_CHECK(
+    std::ranges::random_access_range<FLEX_VECTOR_TRANSIENT_T<std::string>>);
+
 template <typename V = VECTOR_T<unsigned>>
 auto make_test_flex_vector(unsigned min, unsigned max)
 {

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -24,6 +24,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+IMMER_RANGES_CHECK(std::ranges::forward_range<MAP_T<std::string, std::string>>);
+
 using memory_policy_t = MAP_T<unsigned, unsigned>::memory_policy_type;
 
 template <typename T = unsigned>

--- a/test/map_transient/generic.ipp
+++ b/test/map_transient/generic.ipp
@@ -6,6 +6,8 @@
 // See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
 //
 
+#include "test/util.hpp"
+
 #include <catch.hpp>
 
 #ifndef MAP_T
@@ -15,6 +17,10 @@
 #ifndef MAP_TRANSIENT_T
 #error "define the map template to use in MAP_TRANSIENT_T"
 #endif
+
+IMMER_RANGES_CHECK(std::ranges::forward_range<MAP_T<std::string, std::string>>);
+IMMER_RANGES_CHECK(
+    std::ranges::forward_range<MAP_TRANSIENT_T<std::string, std::string>>);
 
 TEST_CASE("instantiate")
 {

--- a/test/set/generic.ipp
+++ b/test/set/generic.ipp
@@ -25,6 +25,9 @@
 
 using memory_policy_t = SET_T<unsigned>::memory_policy_type;
 
+IMMER_RANGES_CHECK(std::input_iterator<SET_T<std::string>::iterator>);
+IMMER_RANGES_CHECK(std::ranges::forward_range<SET_T<std::string>>);
+
 template <typename T = unsigned>
 auto make_generator()
 {

--- a/test/set_transient/generic.ipp
+++ b/test/set_transient/generic.ipp
@@ -6,6 +6,8 @@
 // See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
 //
 
+#include "test/util.hpp"
+
 #include <catch.hpp>
 
 #ifndef SET_T
@@ -15,6 +17,9 @@
 #ifndef SET_TRANSIENT_T
 #error "define the set template to use in SET_TRANSIENT_T"
 #endif
+
+IMMER_RANGES_CHECK(std::ranges::forward_range<SET_T<std::string>>);
+IMMER_RANGES_CHECK(std::ranges::forward_range<SET_TRANSIENT_T<std::string>>);
 
 TEST_CASE("instantiate")
 {

--- a/test/table/generic.ipp
+++ b/test/table/generic.ipp
@@ -63,6 +63,8 @@ using table_map = immer::table<std::pair<K, V>,
                                SETUP_T::memory_policy,
                                SETUP_T::bits>;
 
+IMMER_RANGES_CHECK(std::ranges::forward_range<table_map<std::string, std::string>>);
+
 template <typename T = uint32_t>
 auto make_generator()
 {

--- a/test/table_transient/generic.ipp
+++ b/test/table_transient/generic.ipp
@@ -6,6 +6,8 @@
 // See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
 //
 
+#include "test/util.hpp"
+
 #include <catch.hpp>
 
 #ifndef SETUP_T
@@ -24,6 +26,9 @@ struct Item
         return value == other.value && id == other.id;
     }
 };
+
+IMMER_RANGES_CHECK(std::ranges::forward_range<SETUP_T::table<Item>>);
+IMMER_RANGES_CHECK(std::ranges::forward_range<SETUP_T::table_transient<Item>>);
 
 TEST_CASE("instantiate")
 {

--- a/test/util.hpp
+++ b/test/util.hpp
@@ -12,6 +12,18 @@
 #include <boost/range/join.hpp>
 #include <cstddef>
 
+#include <algorithm> // For __cpp_lib_ranges
+
+// If we have ranges, include the header for the concepts, and define
+// IMMER_RANGES_CHECK() to expand to a static_assert of the argument, otherwise
+// define it as a no-op static_assert.
+#if __cpp_lib_ranges
+#include <ranges>
+#define IMMER_RANGES_CHECK(...) static_assert(__VA_ARGS__)
+#else
+#define IMMER_RANGES_CHECK(...) static_assert(true, "")
+#endif
+
 namespace {
 
 struct identity_t

--- a/test/vector/generic.ipp
+++ b/test/vector/generic.ipp
@@ -25,6 +25,8 @@ using namespace std::string_literals;
 #error "define the vector template to use in VECTOR_T"
 #endif
 
+IMMER_RANGES_CHECK(std::ranges::random_access_range<VECTOR_T<int>>);
+
 template <typename V = VECTOR_T<unsigned>>
 auto make_test_vector(unsigned min, unsigned max)
 {

--- a/test/vector/generic.ipp
+++ b/test/vector/generic.ipp
@@ -120,6 +120,18 @@ TEST_CASE("at")
 #endif
 }
 
+TEST_CASE("random_access iteration")
+{
+    auto v    = VECTOR_T<int>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    auto iter = v.begin();
+    CHECK(*iter == 0);
+    CHECK(iter[0] == 0);
+    CHECK(iter[3] == 3);
+    CHECK(iter[9] == 9);
+    iter += 4;
+    CHECK(iter[-4] == 0);
+}
+
 TEST_CASE("push back one element")
 {
     SECTION("one element")

--- a/test/vector_transient/generic.ipp
+++ b/test/vector_transient/generic.ipp
@@ -20,6 +20,8 @@
 #error "define the vector template to use in VECTOR_TRANSIENT_T"
 #endif
 
+IMMER_RANGES_CHECK(std::ranges::random_access_range<VECTOR_TRANSIENT_T<int>>);
+
 template <typename V = VECTOR_T<unsigned>>
 auto make_test_vector(unsigned min, unsigned max)
 {


### PR DESCRIPTION
Addresses #240, as well as finding a problem with `iterator_facade` not being able to model `random_access_iterator`.

Define tests on each container that it satisfies the intended range concept. (This will transitively validate the iterators as well)

- Fix: `champ_iterator()` was not `default_initializable`, which is a required for `semiregular`, which is required for iterators.
- Fix: `iterator_facade::operator[]` returned a `reference_proxy`, while `iterator_facade::operator*` returns a `ReferenceT`. The `random_access_iterator` concept requires that the operators return an identical type.