### PR TITLE
Fixing annoying unused local variable warning

### DIFF
--- a/immer/heap/cpp_heap.hpp
+++ b/immer/heap/cpp_heap.hpp
@@ -33,7 +33,7 @@ struct cpp_heap
      * `allocate`.  One must not use nor deallocate again a memory
      * region that once it has been deallocated.
      */
-    static void deallocate(std::size_t size, void* data)
+    static void deallocate(std::size_t, void* data)
     {
         ::operator delete(data);
     }


### PR DESCRIPTION
This is an issue that is showing up in Visual Studio 2022/clang-cl and due to the nature of reporting it clutters up the build output window.