### PR TITLE
Fix MSVC compile error C2059

### DIFF
--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -297,7 +297,7 @@ struct node
                     new (vp + 1) T{std::move(x2)};
                 }
                 IMMER_CATCH (...) {
-                    vp->~T();
+                    vp->T::~T();
                     IMMER_RETHROW;
                 }
             }


### PR DESCRIPTION
The following code from your documentation:
```c++
using map_t = immer::map<std::string, int>;
struct part{};
struct whole {
    part p;
    map_t m;
};

lager::state<whole> state = lager::make_state(whole{});
lager::cursor<part> part_cursor =
    state.zoom(lager::lenses::attr(&whole::p));
lager::cursor<map_t> map_cursor =
    state.zoom(lager::lenses::attr(&whole::m));
lager::cursor<int> int_cursor =
    map_cursor.zoom(lager::lenses::at("foo"))
    .zoom(lager::lenses::or_default);
```
Will produce the following error in MSVC when attempting to zoom in on the map element:
```
.../immer/detail/hamts/node.hpp(300,26): error C2059: syntax error: ''symbol''
(followed by many more lines of error message)
```
Qualifying the explicit destructor call with `T::` satisfies the compiler.