### PR TITLE
Fix msvc c2975

### DIFF
--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -49,7 +49,7 @@ struct rrbtree
 
     static node_t* empty_root()
     {
-        static const auto empty_ = [&]{
+        static const auto empty_ = []{
 			constexpr auto size = node_t::sizeof_inner_n(0);
             static std::aligned_storage_t<size, alignof(std::max_align_t)> storage;
             return node_t::make_inner_n_into(&storage, size, 0u);
@@ -59,7 +59,7 @@ struct rrbtree
 
     static node_t* empty_tail()
     {
-        static const auto empty_ = [&]{
+        static const auto empty_ = []{
 			constexpr auto size = node_t::sizeof_leaf_n(0);
             static std::aligned_storage_t<size, alignof(std::max_align_t)> storage;
             return node_t::make_leaf_n_into(&storage, size, 0u);

--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -49,8 +49,8 @@ struct rrbtree
 
     static node_t* empty_root()
     {
-        constexpr auto size = node_t::sizeof_inner_n(0);
         static const auto empty_ = [&]{
+			constexpr auto size = node_t::sizeof_inner_n(0);
             static std::aligned_storage_t<size, alignof(std::max_align_t)> storage;
             return node_t::make_inner_n_into(&storage, size, 0u);
         }();
@@ -59,8 +59,8 @@ struct rrbtree
 
     static node_t* empty_tail()
     {
-        constexpr auto size = node_t::sizeof_leaf_n(0);
         static const auto empty_ = [&]{
+			constexpr auto size = node_t::sizeof_leaf_n(0);
             static std::aligned_storage_t<size, alignof(std::max_align_t)> storage;
             return node_t::make_leaf_n_into(&storage, size, 0u);
         }();

--- a/immer/detail/rbts/rrbtree.hpp
+++ b/immer/detail/rbts/rrbtree.hpp
@@ -50,7 +50,7 @@ struct rrbtree
     static node_t* empty_root()
     {
         static const auto empty_ = []{
-			constexpr auto size = node_t::sizeof_inner_n(0);
+            constexpr auto size = node_t::sizeof_inner_n(0);
             static std::aligned_storage_t<size, alignof(std::max_align_t)> storage;
             return node_t::make_inner_n_into(&storage, size, 0u);
         }();
@@ -60,7 +60,7 @@ struct rrbtree
     static node_t* empty_tail()
     {
         static const auto empty_ = []{
-			constexpr auto size = node_t::sizeof_leaf_n(0);
+            constexpr auto size = node_t::sizeof_leaf_n(0);
             static std::aligned_storage_t<size, alignof(std::max_align_t)> storage;
             return node_t::make_leaf_n_into(&storage, size, 0u);
         }();


### PR DESCRIPTION
In MSVC a constexpr variable loses its constexpr-ness when being captured by a lambda, so the use of `size` in `aligned_storage_t` results in:
`error C2975: '_Len': invalid template argument for 'std::aligned_storage_t', expected compile-time constant expression`