### PR TITLE
Use destroy_at to call explicit destructor in make_inner_n

### DIFF
--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -302,7 +302,7 @@ struct node
                     new (vp + 1) T{std::move(x2)};
                 }
                 IMMER_CATCH (...) {
-                    destroy_at(vp);
+                    immer::detail::hamts::destroy_at(vp);
                     IMMER_RETHROW;
                 }
             }

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -297,7 +297,7 @@ struct node
                     new (vp + 1) T{std::move(x2)};
                 }
                 IMMER_CATCH (...) {
-                    vp->T::~T();
+                    std::destroy_at(vp);
                     IMMER_RETHROW;
                 }
             }

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -15,7 +15,6 @@
 
 #include <cassert>
 #include <cstddef>
-#include <memory>
 
 namespace immer {
 namespace detail {

--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -20,6 +20,11 @@ namespace immer {
 namespace detail {
 namespace hamts {
 
+// For C++14 support.
+// Calling the destructor inline breaks MSVC in some obscure
+// corner cases.
+template <typename T> constexpr void destroy_at(T* p) { p->~T(); }
+
 template <typename T,
           typename Hash,
           typename Equal,
@@ -297,7 +302,7 @@ struct node
                     new (vp + 1) T{std::move(x2)};
                 }
                 IMMER_CATCH (...) {
-                    std::destroy_at(vp);
+                    destroy_at(vp);
                     IMMER_RETHROW;
                 }
             }


### PR DESCRIPTION
This fixes the MSVC madness I was experiencing before. This compiles in both C++17 and C++20 mode.