### PR TITLE
cmake: use ${CMAKE_CURRENT_SOURCE_DIR} where possible

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -4,11 +4,11 @@
 
 add_custom_target(doxygen
   COMMAND doxygen doxygen.config
-  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/doc")
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
 add_custom_target(docs
   COMMAND make html
-  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/doc")
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 add_dependencies(docs doxygen)
 
 set(immer_ssh_method
@@ -18,5 +18,5 @@ set(immer_ssh_method
 add_custom_target(upload-docs
   COMMAND
   rsync -av -e \"${immer_ssh_method}\"
-        ${CMAKE_SOURCE_DIR}/doc/_build/html/*
+        ${CMAKE_CURRENT_SOURCE_DIR}/_build/html/*
         raskolnikov@sinusoid.es:public/immer/)


### PR DESCRIPTION
This makes things rely less on their current relative locations in the sources.