### PR TITLE
champ for_each_chunk_p

### DIFF
--- a/test/algorithm.cpp
+++ b/test/algorithm.cpp
@@ -110,10 +110,9 @@ TEST_CASE("all_of")
     do_check(immer::vector<int>{});
     do_check(immer::flex_vector<int>{});
     do_check(immer::array<int>{});
-    // not supported
-    // do_check(immer::map<int, int>{});
-    // do_check(immer::set<int>{});
-    // do_check(immer::table<thing>{});
+    do_check(immer::map<int, int>{});
+    do_check(immer::set<int>{});
+    do_check(immer::table<thing>{});
 }
 
 TEST_CASE("update vectors")

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -271,6 +271,9 @@ TEST_CASE("all_of")
     static const auto all_identity = [](const auto& keyval) {
         return keyval.first == keyval.second;
     };
+    static const auto all_less_n = [](const auto& keyval) {
+        return keyval.second < n;
+    };
     static const auto all_less_n2 = [](const auto& keyval) {
         return keyval.second < n / 2;
     };
@@ -289,6 +292,21 @@ TEST_CASE("all_of")
 
     SECTION("All less n/2 (false)")
     {
+        bool result = immer::all_of(v, all_less_n2);
+        CHECK(!result);
+    }
+
+    SECTION("All less n w/ collisions (true)")
+    {
+        auto vals   = make_values_with_collisions(n);
+        auto s      = make_test_map(vals);
+        bool result = immer::all_of(v, all_less_n);
+        CHECK(result);
+    }
+    SECTION("All less n/2 w/ collisions (false)")
+    {
+        auto vals   = make_values_with_collisions(n);
+        auto s      = make_test_map(vals);
         bool result = immer::all_of(v, all_less_n2);
         CHECK(!result);
     }

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -263,6 +263,37 @@ TEST_CASE("accumulate")
     }
 }
 
+TEST_CASE("all_of")
+{
+    static const auto n = 666u;
+    auto v              = make_test_map(n);
+
+    static const auto all_identity = [](const auto& keyval) {
+        return keyval.first == keyval.second;
+    };
+    static const auto all_less_n2 = [](const auto& keyval) {
+        return keyval.second < n / 2;
+    };
+
+    SECTION("All identity (true)")
+    {
+        bool result = immer::all_of(v, all_identity);
+        CHECK(result);
+    }
+
+    SECTION("Empty (true)")
+    {
+        bool result = immer::all_of(make_test_map(0), all_identity);
+        CHECK(result);
+    }
+
+    SECTION("All less n/2 (false)")
+    {
+        bool result = immer::all_of(v, all_less_n2);
+        CHECK(!result);
+    }
+}
+
 TEST_CASE("update a lot")
 {
     auto v = make_test_map(666u);


### PR DESCRIPTION
Currently, the immer `set`, `map`, and `table` containers only support a subset of available algorithms; especially `immer::all_of` is not supported. That is, because the underlying `champ` does not implement `for_each_chunk_p`.

This PR adds an implementation of `for_each_chunk_p` to the above mentioned `champ`. Should be related to #171.

Design considerations:
- iterative- vs recursive implementation: As `for_each_chunk_p may be part of extremely hot parts of user-code, I prefer to avoid non-tail recursion
- Worklist vs explicit stack: The easiest non-recursive implementation would be based on a worklist of `const node_t *`. However, this has the drawback of potential memory allocation, so the implementation uses an explicit stack (`std::array`) that models the required parts of the call-stack from `for_each_chunk_traversal`. 
- Question: Should we `std::invoke` the callback if compiled with C++17 or higher?