### PR TITLE
champ try_update

### DIFF
--- a/immer/detail/util.hpp
+++ b/immer/detail/util.hpp
@@ -317,7 +317,9 @@ static constexpr bool can_efficiently_pass_by_value =
 
 template <typename T, typename OrElse = const T&>
 using byval_if_possible =
-    std::conditional_t<can_efficiently_pass_by_value<T>, T, OrElse>;
+    std::conditional_t<can_efficiently_pass_by_value<std::decay_t<T>>,
+                       std::decay_t<T>,
+                       OrElse>;
 
 } // namespace detail
 } // namespace immer

--- a/immer/detail/util.hpp
+++ b/immer/detail/util.hpp
@@ -102,9 +102,9 @@ auto destroy_n(Iter first, Size n) noexcept
 template <typename Iter1, typename Iter2>
 constexpr bool can_trivially_copy =
     std::is_same<typename std::iterator_traits<Iter1>::value_type,
-                 typename std::iterator_traits<Iter2>::value_type>::value&&
-        std::is_trivially_copyable<
-            typename std::iterator_traits<Iter1>::value_type>::value;
+                 typename std::iterator_traits<Iter2>::value_type>::value &&
+    std::is_trivially_copyable<
+        typename std::iterator_traits<Iter1>::value_type>::value;
 
 template <typename Iter1, typename Iter2>
 auto uninitialized_move(Iter1 first, Iter1 last, Iter2 out) noexcept
@@ -233,7 +233,8 @@ auto static_if(F&& f) -> std::enable_if_t<b>
 }
 template <bool b, typename F>
 auto static_if(F&& f) -> std::enable_if_t<!b>
-{}
+{
+}
 
 template <bool b, typename R = void, typename F1, typename F2>
 auto static_if(F1&& f1, F2&& f2) -> std::enable_if_t<b, R>
@@ -309,6 +310,14 @@ distance(Iterator first, Sentinel last)
 {
     return last - first;
 }
+
+template <typename T>
+static constexpr bool can_efficiently_pass_by_value =
+    sizeof(T) <= 2 * sizeof(void*) && std::is_trivially_copyable<T>::value;
+
+template <typename T, typename OrElse = const T&>
+using byval_if_possible =
+    std::conditional_t<can_efficiently_pass_by_value<T>, T, OrElse>;
 
 } // namespace detail
 } // namespace immer

--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -177,7 +177,8 @@ public:
      */
     map(std::initializer_list<value_type> values)
         : impl_{impl_t::from_initializer_list(values)}
-    {}
+    {
+    }
 
     /*!
      * Constructs a map containing the elements in the range
@@ -189,7 +190,8 @@ public:
                                bool> = true>
     map(Iter first, Sent last)
         : impl_{impl_t::from_range(first, last)}
-    {}
+    {
+    }
 
     /*!
      * Default constructor.  It creates a map of `size() == 0`.  It
@@ -425,6 +427,37 @@ public:
     }
 
     /*!
+     * Returns a map replacing the association `(k, v)` by the
+     * association new association `(k, fn(v))`, where `v` is the
+     * currently associated value for `k` in the map or a default
+     * constructed value otherwise. It may allocate memory
+     * and its complexity is *effectively* @f$ O(1) @f$.
+     *
+     * If `fn(v) == v`, the map remains unchanged and no memory is allocated.
+     * You may customize the equality comparison for values by setting the
+     * ValueEquals callback
+     */
+    template <typename Fn, typename ValueEquals = std::equal_to<mapped_type>>
+    IMMER_NODISCARD map try_update(key_type k,
+                                   Fn&& fn,
+                                   ValueEquals valueEquals = {}) const&
+    {
+        return impl_
+            .template try_update<project_value, default_value, combine_value>(
+                std::move(k), std::forward<Fn>(fn), std::move(valueEquals));
+    }
+
+    template <typename Fn, typename ValueEquals = std::equal_to<mapped_type>>
+    IMMER_NODISCARD decltype(auto)
+    try_update(key_type k, Fn&& fn, ValueEquals valueEquals = {}) &&
+    {
+        return try_update_move(move_t{},
+                               std::move(k),
+                               std::forward<Fn>(fn),
+                               std::move(valueEquals));
+    }
+
+    /*!
      * Returns a map replacing the association `(k, v)` by the association new
      * association `(k, fn(v))`, where `v` is the currently associated value for
      * `k` in the map.  It does nothing if `k` is not present in the map. It
@@ -516,6 +549,29 @@ private:
                 std::move(k), std::forward<Fn>(fn));
     }
 
+    template <typename Fn, typename ValueEquals>
+    map&& try_update_move(std::true_type,
+                          key_type k,
+                          Fn&& fn,
+                          ValueEquals valueEquals)
+    {
+        impl_.template try_update_mut<project_value,
+                                      default_value,
+                                      combine_value>(
+            {}, std::move(k), std::forward<Fn>(fn), std::move(valueEquals));
+        return std::move(*this);
+    }
+    template <typename Fn, typename ValueEquals>
+    map try_update_move(std::false_type,
+                        key_type k,
+                        Fn&& fn,
+                        ValueEquals valueEquals)
+    {
+        return impl_
+            .template try_update<project_value, default_value, combine_value>(
+                std::move(k), std::forward<Fn>(fn), std::move(valueEquals));
+    }
+
     template <typename Fn>
     map&& update_if_exists_move(std::true_type, key_type k, Fn&& fn)
     {
@@ -542,7 +598,8 @@ private:
 
     map(impl_t impl)
         : impl_(std::move(impl))
-    {}
+    {
+    }
 
     impl_t impl_ = impl_t::empty();
 };

--- a/test/algorithm.cpp
+++ b/test/algorithm.cpp
@@ -150,6 +150,23 @@ TEST_CASE("update maps")
     do_check(immer::table<thing>{});
 }
 
+TEST_CASE("try update maps")
+{
+    auto do_check = [](auto v) {
+        (void) v.try_update(0, [](auto&& x) {
+            using type_t = std::decay_t<decltype(x)>;
+            // for maps, we actually do not make a copy at all but pase the
+            // original instance directly, as const..
+            static_assert(std::is_same<const type_t&, decltype(x)>::value, "");
+            return x;
+        });
+    };
+
+    do_check(immer::map<int, int>{});
+    // -- tables not supported yet with try_update
+    // do_check(immer::table<thing>{});
+}
+
 TEST_CASE("update_if_exists maps")
 {
     auto do_check = [](auto v) {

--- a/test/map/generic.ipp
+++ b/test/map/generic.ipp
@@ -171,6 +171,9 @@ TEST_CASE("equals and setting")
     CHECK(v.set(1234, 42) == v.insert({1234, 42}));
     CHECK(v.update(1234, [](auto&& x) { return x + 1; }) == v.set(1234, 1));
     CHECK(v.update(42, [](auto&& x) { return x + 1; }) == v.set(42, 43));
+    CHECK(v.try_update(42, [](auto&& x) { return x + 1; }) == v.set(42, 43));
+    CHECK(v.try_update(42, [](auto&& x) { return x; }).identity() ==
+          v.identity());
 
     CHECK(v.update_if_exists(1234, [](auto&& x) { return x + 1; }) == v);
     CHECK(v.update_if_exists(42, [](auto&& x) { return x + 1; }) ==
@@ -278,6 +281,22 @@ TEST_CASE("update a lot")
     {
         for (decltype(v.size()) i = 0; i < v.size(); ++i) {
             v = std::move(v).update(i, [](auto&& x) { return x + 1; });
+            CHECK(v[i] == i + 1);
+        }
+    }
+
+    SECTION("try_update immutable")
+    {
+        for (decltype(v.size()) i = 0; i < v.size(); ++i) {
+            v = v.try_update(i, [](auto&& x) { return x + 1; });
+            CHECK(v[i] == i + 1);
+        }
+    }
+
+    SECTION("try_update move")
+    {
+        for (decltype(v.size()) i = 0; i < v.size(); ++i) {
+            v = std::move(v).try_update(i, [](auto&& x) { return x + 1; });
             CHECK(v[i] == i + 1);
         }
     }
@@ -439,7 +458,8 @@ TEST_CASE("exception safety")
                 auto s = d.next();
                 v      = v.update(i, [](auto x) { return x + 1; });
                 ++i;
-            } catch (dada_error) {}
+            } catch (dada_error) {
+            }
             for (auto i : test_irange(0u, i))
                 CHECK(v.at(i) == i + 1);
             for (auto i : test_irange(i, n))
@@ -460,7 +480,8 @@ TEST_CASE("exception safety")
                 auto s = d.next();
                 v      = v.update_if_exists(i, [](auto x) { return x + 1; });
                 ++i;
-            } catch (dada_error) {}
+            } catch (dada_error) {
+            }
             for (auto i : test_irange(0u, i))
                 CHECK(v.at(i) == i + 1);
             for (auto i : test_irange(i, n))
@@ -482,7 +503,8 @@ TEST_CASE("exception safety")
                 auto s = d.next();
                 v      = v.update(vals[i].first, [](auto x) { return x + 1; });
                 ++i;
-            } catch (dada_error) {}
+            } catch (dada_error) {
+            }
             for (auto i : test_irange(0u, i))
                 CHECK(v.at(vals[i].first) == vals[i].second + 1);
             for (auto i : test_irange(i, n))
@@ -505,7 +527,8 @@ TEST_CASE("exception safety")
                 v      = v.update_if_exists(vals[i].first,
                                        [](auto x) { return x + 1; });
                 ++i;
-            } catch (dada_error) {}
+            } catch (dada_error) {
+            }
             for (auto i : test_irange(0u, i))
                 CHECK(v.at(vals[i].first) == vals[i].second + 1);
             for (auto i : test_irange(i, n))
@@ -528,7 +551,8 @@ TEST_CASE("exception safety")
                 auto x = vals[i].second;
                 v      = v.set(vals[i].first, x + 1);
                 ++i;
-            } catch (dada_error) {}
+            } catch (dada_error) {
+            }
             for (auto i : test_irange(0u, i))
                 CHECK(v.at(vals[i].first) == vals[i].second + 1);
             for (auto i : test_irange(i, n))
@@ -551,7 +575,8 @@ TEST_CASE("exception safety")
                 auto x = vals[i].second;
                 v      = std::move(v).set(vals[i].first, x + 1);
                 ++i;
-            } catch (dada_error) {}
+            } catch (dada_error) {
+            }
             for (auto i : test_irange(0u, i))
                 CHECK(v.at(vals[i].first) == vals[i].second + 1);
             for (auto i : test_irange(i, n))
@@ -574,7 +599,8 @@ TEST_CASE("exception safety")
                 v      = std::move(v).update(vals[i].first,
                                         [](auto x) { return x + 1; });
                 ++i;
-            } catch (dada_error) {}
+            } catch (dada_error) {
+            }
             for (auto i : test_irange(0u, i))
                 CHECK(v.at(vals[i].first) == vals[i].second + 1);
             for (auto i : test_irange(i, n))
@@ -597,7 +623,8 @@ TEST_CASE("exception safety")
                 v      = std::move(v).update_if_exists(vals[i].first,
                                                   [](auto x) { return x + 1; });
                 ++i;
-            } catch (dada_error) {}
+            } catch (dada_error) {
+            }
             for (auto i : test_irange(0u, i))
                 CHECK(v.at(vals[i].first) == vals[i].second + 1);
             for (auto i : test_irange(i, n))
@@ -619,7 +646,8 @@ TEST_CASE("exception safety")
                 // auto s = d.next();
                 v = std::move(v).erase(vals[i].first);
                 ++i;
-            } catch (dada_error) {}
+            } catch (dada_error) {
+            }
             for (auto i : test_irange(0u, i))
                 CHECK(v.count(vals[i].first) == 0);
             for (auto i : test_irange(i, n))
@@ -635,7 +663,8 @@ struct KeyType
 {
     explicit KeyType(unsigned v)
         : value(v)
-    {}
+    {
+    }
     unsigned value;
 };
 
@@ -643,7 +672,8 @@ struct LookupType
 {
     explicit LookupType(unsigned v)
         : value(v)
-    {}
+    {
+    }
     unsigned value;
 };
 


### PR DESCRIPTION
## Story

As a user of `immer`, I want to efficiently build up nested `map<set>` structures in an incremental way, until reaching a fixpoint achieving maximum performance.
This involves frequent updates of the nested `set`s inside the map.
The obvious solution for this problem is using the `immer::map::update` function to update the inner sets.
However, I have found that `update` always re-allocates -- even if the updated value is identical to the already present value leaving a lot pf performance on the table.
This for example happens if inserting an element to an inner set that has already been present.

As a fallback solution, I currently do the following:

```C++
const auto *SetPtr = map.find(Key);
if (!SetPtr)
  return map.set(std::move(Key), makeSingletonSet(std::move(Value));

auto NewSet = SetPtr->insert(std::move(Value));
if (NewSet == *OldSet)
  return map;

return map.set(std::move(Key), std::move(NewSet));
```
Whereas I really want to do:

```C++
return map.update(std::move(Key), [Value = std::move(Value)] (const auto &OldSet){
  return OldSet.insert(std::move(Value));
});
```

## Solution Proposal

As a solution to above problem, I propose a new API `try_update` within `immer::map` that works similar to `update`, just adds an additional equality check on the result of the callback `fn` and in case of equality leaves the map unchanged.

This PR implements `try_update` on the `champ` and provides an according public API to `immer::map`.
In addition, it fixes a minor issue that the `champ::update` function takes the key by const-ref, although the underlying `do_update` function can deal with perfectly forwarded keys.

Design decisions:
- Implement `do_try_update` and `do_try_update_mut` within an inner struct allowing to recursively call mentioned functions without specifying the template arguments again.
- Use the same signature as `do_update[_mut]` and use a `nullptr` node as indicator that nothing has changed.
- Pass the key, the updater-fn and the value-equals-fn by value if they are small and trivial. This adds potential to the optimizer to pass these arguments in registers without touching any memory. Empty arguments, such as `std::equal_to` for value-equals can even be elided completely. 
  As a policy, when to pass by value, I implemented the `byval_if_possible` type-trait preferring by-value for trivial types that are not larger than two pointers. This more-or-less matches the behavior of the x86-64 parameter passing conventions of the Itanium ABI (refer to https://gitlab.com/x86-psABIs/x86-64-ABI/ chapter 3.2.3 Parameter Passing)