### PR TITLE
Fix portability of IMMER_THROW when exceptions are disabled

### DIFF
--- a/immer/config.hpp
+++ b/immer/config.hpp
@@ -33,7 +33,7 @@
 #define IMMER_CATCH(expr) else
 #define IMMER_THROW(expr)                                                      \
     do {                                                                       \
-        assert(!#expr);                                                        \
+        assert((#expr, false));                                                \
         std::terminate();                                                      \
     } while (false)
 #define IMMER_RETHROW


### PR DESCRIPTION
The current implementation of IMMER_THROW when exceptions are disabled relies on the compiler converting a character array to a truthy value, which can throw warnings and is not truly portable. Instead, we can use the comma operator to portably add additional data to an assertion: https://en.cppreference.com/w/cpp/error/assert.