### PR TITLE
Fixes `difference_type` being mispelled as `diference_type`.

### DIFF
--- a/immer/map.hpp
+++ b/immer/map.hpp
@@ -158,7 +158,7 @@ public:
     using mapped_type     = T;
     using value_type      = std::pair<K, T>;
     using size_type       = detail::hamts::size_t;
-    using diference_type  = std::ptrdiff_t;
+    using difference_type  = std::ptrdiff_t;
     using hasher          = Hash;
     using key_equal       = Equal;
     using reference       = const value_type&;

--- a/immer/map_transient.hpp
+++ b/immer/map_transient.hpp
@@ -51,7 +51,7 @@ public:
     using mapped_type     = T;
     using value_type      = std::pair<K, T>;
     using size_type       = detail::hamts::size_t;
-    using diference_type  = std::ptrdiff_t;
+    using difference_type  = std::ptrdiff_t;
     using hasher          = Hash;
     using key_equal       = Equal;
     using reference       = const value_type&;

--- a/immer/set.hpp
+++ b/immer/set.hpp
@@ -73,7 +73,7 @@ class set
 public:
     using value_type      = T;
     using size_type       = detail::hamts::size_t;
-    using diference_type  = std::ptrdiff_t;
+    using difference_type  = std::ptrdiff_t;
     using hasher          = Hash;
     using key_equal       = Equal;
     using reference       = const T&;

--- a/immer/set_transient.hpp
+++ b/immer/set_transient.hpp
@@ -40,7 +40,7 @@ public:
 
     using value_type      = T;
     using size_type       = detail::hamts::size_t;
-    using diference_type  = std::ptrdiff_t;
+    using difference_type  = std::ptrdiff_t;
     using hasher          = Hash;
     using key_equal       = Equal;
     using reference       = const T&;

--- a/immer/table.hpp
+++ b/immer/table.hpp
@@ -193,7 +193,7 @@ public:
     using mapped_type     = T;
     using value_type      = T;
     using size_type       = detail::hamts::size_t;
-    using diference_type  = std::ptrdiff_t;
+    using difference_type  = std::ptrdiff_t;
     using hasher          = Hash;
     using key_equal       = Equal;
     using reference       = const value_type&;

--- a/immer/table_transient.hpp
+++ b/immer/table_transient.hpp
@@ -42,7 +42,7 @@ public:
     using mapped_type     = T;
     using value_type      = T;
     using size_type       = detail::hamts::size_t;
-    using diference_type  = std::ptrdiff_t;
+    using difference_type  = std::ptrdiff_t;
     using hasher          = Hash;
     using key_equal       = Equal;
     using reference       = const value_type&;


### PR DESCRIPTION
This fixes the type alias `difference_type` which was mispelled as `diference_type` in `map`, `set`, `table`, and their transients. This may potentially break some generic code, although these aliases are not used as much as in the past nowadays.