### PR TITLE
Make immer::box work with forward declared types

### DIFF
--- a/immer/box.hpp
+++ b/immer/box.hpp
@@ -74,8 +74,7 @@ public:
      */
     template <typename Arg,
               typename Enable = std::enable_if_t<
-                  !std::is_same<box, std::decay_t<Arg>>::value &&
-                  std::is_constructible<T, Arg>::value>>
+                  !std::is_same<box, std::decay_t<Arg>>::value>>
     box(Arg&& arg)
         : impl_{detail::make<heap, holder>(std::forward<Arg>(arg))}
     {}

--- a/test/box/generic.ipp
+++ b/test/box/generic.ipp
@@ -141,3 +141,21 @@ TEST_CASE("update move")
         CHECK(&y.get() == addr);
     }
 }
+
+namespace {
+struct fwd_type;
+struct test_type
+{
+    immer::box<fwd_type> data;
+};
+struct fwd_type
+{
+    int data = 123;
+};
+} // namespace
+
+TEST_CASE("Test box with a fwd declared type")
+{
+    auto val = test_type{};
+    REQUIRE(val.data.get().data == 123);
+}


### PR DESCRIPTION
Thanks @alex-sparus for reporting and fixing this one!

Based on: https://github.com/alex-sparus/immer/commit/c29e7ff9ac8478e78ba568d3d74a7a7c937456f9