### PR TITLE
Remove usage of `std::aligned_storage` to switch off deprecation warnings in C++23

### DIFF
--- a/immer/detail/util.hpp
+++ b/immer/detail/util.hpp
@@ -36,9 +36,20 @@ const T& as_const(T& x)
     return x;
 }
 
+template<std::size_t Size, std::size_t Align>
+struct aligned_storage
+{
+    struct type {
+        alignas(Align) unsigned char data[Size] = { };
+    };
+};
+
+template<std::size_t Size, std::size_t Align>
+using aligned_storage_t = typename aligned_storage<Size, Align>::type;
+
 template <typename T>
 using aligned_storage_for =
-    typename std::aligned_storage<sizeof(T), alignof(T)>::type;
+    typename aligned_storage<sizeof(T), alignof(T)>::type;
 
 template <typename T>
 T& auto_const_cast(const T& x)

--- a/immer/detail/util.hpp
+++ b/immer/detail/util.hpp
@@ -40,7 +40,7 @@ template<std::size_t Size, std::size_t Align>
 struct aligned_storage
 {
     struct type {
-        alignas(Align) unsigned char data[Size] = { };
+        alignas(Align) unsigned char data[Size];
     };
 };
 

--- a/immer/heap/debug_size_heap.hpp
+++ b/immer/heap/debug_size_heap.hpp
@@ -39,7 +39,10 @@ struct debug_size_heap
     constexpr static auto extra_size = 8;
 #else
     constexpr static auto extra_size = sizeof(
-        std::aligned_storage_t<sizeof(std::size_t), alignof(std::max_align_t)>);
+        detail::aligned_storage_t<
+            sizeof(std::size_t), alignof(std::max_align_t)
+        >
+    );
 #endif
 
     template <typename... Tags>

--- a/immer/heap/debug_size_heap.hpp
+++ b/immer/heap/debug_size_heap.hpp
@@ -10,6 +10,7 @@
 
 #include <immer/config.hpp>
 #include <immer/heap/identity_heap.hpp>
+#include <immer/detail/util.hpp>
 
 #include <cassert>
 #include <cstddef>


### PR DESCRIPTION
This PR effectively adds a simple implementation of `std::aligned_storage` in the `immer::detail` namespace to avoid using the `std` one which causes deprecation warnings. This is meant to close #283. 