### PR TITLE
Add missed clear to unsafe_free_list_storage

### DIFF
--- a/immer/heap/unsafe_free_list_heap.hpp
+++ b/immer/heap/unsafe_free_list_heap.hpp
@@ -24,6 +24,8 @@ struct unsafe_free_list_storage
     {
         free_list_node* data;
         std::size_t count;
+
+        ~head_t() { Heap::clear(); }
     };
 
     static head_t& head()


### PR DESCRIPTION
We encountered different behavior of thread_local_free_list_heap and unsafe_free_list_heap data structures even when used in the single thread environment.

Unfortunately I am still in the process of building a small test to reproduce it, but while reading the code I noticed that the clear function is not called for unsafe_free_list_storage similarly to the thread_local_free_list_storage container. 
Is this expected behavior? 
