### PR TITLE
Add default ctor ability to gc policy's edit

### DIFF
--- a/immer/transience/gc_transience_policy.hpp
+++ b/immer/transience/gc_transience_policy.hpp
@@ -39,12 +39,8 @@ struct gc_transience_policy
 
             struct edit
             {
-                void* v;
-                edit(void* v_)
-                    : v{v_}
-                {
-                }
-                edit() = delete;
+                void* v{};
+
                 bool operator==(edit x) const { return v == x.v; }
                 bool operator!=(edit x) const { return v != x.v; }
             };


### PR DESCRIPTION
This code was incorrect before, from everything I can tell. I suspect a Clang issue for why it never failed before. It boils down to this:

* The GC policy's `edit` type is not default constructible: https://github.com/arximboldi/immer/blob/master/immer/transience/gc_transience_policy.hpp#L47
* map, set, and vector all default construct their `edit` in a few places

What I did to make it show up:

* I moved my immer map, vector, set instantiations to an `extern template`, with one definition in a `.cpp` file

Originally, I fixed this by changing `{}` to `{nullptr}`, but that won't work for other policies, such as this: https://github.com/arximboldi/immer/blob/master/immer/transience/no_transience_policy.hpp#L24

Instead, I have made the GC policy's `edit` default constructible. The `void*` ctor was removed, since aggregate initialization can now just be used instead.