### PR TITLE
Use sfinea to conditionally exclude iterator facade operators

### DIFF
--- a/immer/detail/iterator_facade.hpp
+++ b/immer/detail/iterator_facade.hpp
@@ -98,9 +98,11 @@ protected:
 public:
     ReferenceT operator*() const { return access_t::dereference(derived()); }
     PointerT operator->() const { return &access_t::dereference(derived()); }
+
+    template <typename U = iterator_facade,
+              typename std::enable_if_t<U::is_random_access, bool> = true>
     ReferenceT operator[](DifferenceTypeT n) const
     {
-        static_assert(is_random_access, "");
         return *(derived() + n);
     }
 
@@ -125,15 +127,21 @@ public:
         return tmp;
     }
 
+    template <
+        typename U                      = iterator_facade,
+        typename std::enable_if_t<U::is_bidirectional || U::is_random_access,
+                                  bool> = true>
     DerivedT& operator--()
     {
-        static_assert(is_bidirectional || is_random_access, "");
         access_t::decrement(derived());
         return derived();
     }
+    template <
+        typename U                      = iterator_facade,
+        typename std::enable_if_t<U::is_bidirectional || U::is_random_access,
+                                  bool> = true>
     DerivedT operator--(int)
     {
-        static_assert(is_bidirectional || is_random_access, "");
         auto tmp = derived();
         access_t::decrement(derived());
         return tmp;
@@ -150,47 +158,58 @@ public:
         return derived();
     }
 
+    template <typename U = iterator_facade,
+              typename std::enable_if_t<U::is_random_access, bool> = true>
     DerivedT operator+(DifferenceTypeT n) const
     {
-        static_assert(is_random_access, "");
         auto tmp = derived();
         return tmp += n;
     }
+    template <typename U = iterator_facade,
+              typename std::enable_if_t<U::is_random_access, bool> = true>
     friend DerivedT operator+(DifferenceTypeT n, const DerivedT& i)
     {
-        static_assert(is_random_access, "");
         return i + n;
     }
+    template <typename U = iterator_facade,
+              typename std::enable_if_t<U::is_random_access, bool> = true>
     DerivedT operator-(DifferenceTypeT n) const
     {
-        static_assert(is_random_access, "");
         auto tmp = derived();
         return tmp -= n;
     }
+
+    template <typename U = iterator_facade,
+              typename std::enable_if_t<U::is_random_access, bool> = true>
     friend DifferenceTypeT operator-(const DerivedT& a, const DerivedT& b)
     {
-        static_assert(is_random_access, "");
         return access_t::distance_to(b, a);
     }
 
+    template <typename U = iterator_facade,
+              typename std::enable_if_t<U::is_random_access, bool> = true>
     friend bool operator<(const DerivedT& a, const DerivedT& b)
+
     {
-        static_assert(is_random_access, "");
         return access_t::distance_to(a, b) > 0;
     }
+    template <typename U = iterator_facade,
+              typename std::enable_if_t<U::is_random_access, bool> = true>
     friend bool operator<=(const DerivedT& a, const DerivedT& b)
     {
-        static_assert(is_random_access, "");
         return access_t::distance_to(a, b) >= 0;
     }
+    template <typename U = iterator_facade,
+              typename std::enable_if_t<U::is_random_access, bool> = true>
     friend bool operator>(const DerivedT& a, const DerivedT& b)
+
     {
-        static_assert(is_random_access, "");
         return access_t::distance_to(a, b) < 0;
     }
+    template <typename U = iterator_facade,
+              typename std::enable_if_t<U::is_random_access, bool> = true>
     friend bool operator>=(const DerivedT& a, const DerivedT& b)
     {
-        static_assert(is_random_access, "");
         return access_t::distance_to(a, b) <= 0;
     }
 };


### PR DESCRIPTION
This fixes an issue that showed up on recent compiler version -- e.g. gcc 14.3 -- in which the std::sized_sentinel_for concept would evaluate to true on forward iterator types in spite of the fact that their operator- would fail to compile. This only occured with C++20 or greater. This prevented doing things like

  auto m = immer::map<int,int>{{0,0}, {1,1}}
  auto v = std::vector<std::pair<int,int>>(m.begin(), m.end());

or

  auto n = std::ranges::distance(m.begin(), m.end());

This was due to the fact that static_asserts were used to exclude certain operators at compile time, but C++ concepts basically ignore those. This would then lead the standard library to chose implementations relying on operators that couldn't compile.

Link:

https://en.cppreference.com/w/cpp/iterator/sized_sentinel_for.html

Issue:

https://github.com/arximboldi/immer/issues/302