### PR TITLE
include <exception> for std::termiate

### DIFF
--- a/immer/detail/rbts/operations.hpp
+++ b/immer/detail/rbts/operations.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <algorithm>
+#include <exception>
 #include <memory>
 #include <numeric>
 #include <utility>


### PR DESCRIPTION
since we are using std::terminate we should include <exception>