### PR TITLE
Fix configure on FreeBSD

### DIFF
--- a/cmake/FindBoehmGC.cmake
+++ b/cmake/FindBoehmGC.cmake
@@ -52,7 +52,7 @@ endif()
 # For FreeBSD we need to use gc-threaded
 if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
   # checks if 'gc' supports 'GC_get_parallel' and if it does then use it
-  include(${CMAKE_ROOT}/Modules/CheckCSourceCompiles.cmake)
+  include(${CMAKE_ROOT}/Modules/CheckCSourceRuns.cmake)
   # not sure if this links properly...
   find_library(
     BOEHM_GC_LIBRARIES


### PR DESCRIPTION
Include correct CMake module for check_c_source_runs() in [cmake/FindBoehmGC.cmake](https://github.com/arximboldi/immer/blob/master/cmake/FindBoehmGC.cmake).

On FreeBSD, configure fails with:
```
CMake Error at cmake/FindBoehmGC.cmake:67 (check_c_source_runs):
  Unknown CMake command "check_c_source_runs".
```
I'm the maintainer for the [devel/immer](https://cgit.freebsd.org/ports/tree/devel/immer) port on FreeBSD and have been patching this locally for over 2 years, so this change has been pretty well tested.