### PR TITLE
Fix GCC would issue false warning when compiling with `-Os`

### DIFF
--- a/immer/detail/rbts/node.hpp
+++ b/immer/detail/rbts/node.hpp
@@ -24,6 +24,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Wnonnull"
 
 namespace immer {
 namespace detail {


### PR DESCRIPTION
Closes #307